### PR TITLE
change for centos "ip link set master" to "brctl"

### DIFF
--- a/pipework
+++ b/pipework
@@ -115,7 +115,8 @@ ln -s /proc/$NSPID/ns/net /var/run/netns/$NSPID
     LOCAL_IFNAME=vethl$NSPID
     GUEST_IFNAME=vethg$NSPID
     ip link add name $LOCAL_IFNAME type veth peer name $GUEST_IFNAME
-    ip link set $LOCAL_IFNAME master $IFNAME
+    #ip link set $LOCAL_IFNAME master $IFNAME
+    brctl addif $IFNAME $LOCAL_IFNAME
     ip link set $LOCAL_IFNAME up
 }
 


### PR DESCRIPTION
centos's ip link command don't know "master".
