### PR TITLE
Check for eth1/carrier instead of eth1/operstate

### DIFF
--- a/pipework
+++ b/pipework
@@ -3,7 +3,7 @@ set -e
 
 case "$1" in
     --wait)
-	while ! grep -q ^up$ /sys/class/net/eth1/operstate 2>/dev/null
+	while ! grep -q ^1$ /sys/class/net/eth1/carrier 2>/dev/null
 	do sleep 1
 	done
 	exit 0


### PR DESCRIPTION
eth1/operstate seems to be 'unknown' sometimes, even if the interface
is up and working as expected.

This will close #18.
