### PR TITLE
Return 0 if everything went fine

### DIFF
--- a/pipework
+++ b/pipework
@@ -177,3 +177,4 @@ else
 	ip netns exec $NSPID ip route replace default via $GATEWAY
     }
 fi
+exit 0


### PR DESCRIPTION
Without this, pipework will return the exit status of the last command
which is [ "$IPADDR" = "dhcp" ] or [ "$GATEWAY" ] in this case
