### PR TITLE
Improve argument parsing, and allow establishment of route(s) via the new container interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,12 @@ Want to connect to those containers using their private addresses? Easy:
 Voilà!
 
 ## Setting container internal interface ##
-By default pipework creates a new interface `eth1` inside the container. In case you want to change this interface name like `eth2`, e.g., to have more than one interface set by pipework, use:
 
-`pipework br1 -i eth2 ...`
+By default pipework creates a new interface `eth1` inside the container. In case
+you want to change this interface name like `eth2`, e.g., to have more than one
+interface set by pipework, use -i <name> (or --interface):
+
+    pipework br1 -i eth2 ...
 
 ## Using a different netmask
 
@@ -103,6 +106,15 @@ Don't forget that all containers should use the same subnet size;
 pipework is not clever enough to use your specified subnet size for
 the first container, and retain it to use it for the other containers.
 
+## Establishing routes over the new interface
+
+If you wish, you may establish any number of new routes using the new interface.
+For example, to route multicast over the new interface:
+
+    pipework br1 --route 224.0.0.0/4 ...
+
+These routes are established after the new interface is brought up, and before
+any default gateway is set.
 
 ## Setting a default gateway
 

--- a/pipework
+++ b/pipework
@@ -225,9 +225,9 @@ if [ "$IPADDR" = "dhcp" ]; then
 else
     (( VERB )) && echo "Bringing up dev $CONTAINER_IFNAME manually w/ IP address $IPADDR"
     ip netns exec $NSPID ip addr add $IPADDR dev $CONTAINER_IFNAME
-    [ "$GATEWAY" ] && {
-	ip netns exec $NSPID ip route delete default >/dev/null 2>&1 && true
-    }
+    if [ "$GATEWAY" ]; then
+	ip netns exec $NSPID ip route delete default >/dev/null 2>&1 || true
+    fi
     ip netns exec $NSPID ip link set $CONTAINER_IFNAME up
 fi
 

--- a/pipework
+++ b/pipework
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+# Exit immediately, if any command fails without being captured by an if ...; then
 set -e
 
 CONTAINER_IFNAME=eth1
@@ -47,6 +49,7 @@ while (( $# )); do
     shift
 done
 
+# Validate args, ensuring that at least an IPADDR was provided
 [ "$WAIT" ] && {
   while ! grep -q ^1$ /sys/class/net/$CONTAINER_IFNAME/carrier 2>/dev/null
   do sleep 1
@@ -70,6 +73,29 @@ done
     exit 1
 }
 
+if [ "$IPADDR" = "dhcp" ]; then
+    # We use udhcpc to obtain the DHCP lease, make sure it's installed.
+    which udhcpc >/dev/null || {
+        echo "You asked for DHCP; please install udhcpc first."
+        exit 1
+    }
+else
+    # Check if a subnet mask was provided.
+    echo $IPADDR | grep -q / || {
+        echo "The IP address should include a netmask."
+        echo "Maybe you meant $IPADDR/24 ?"
+        exit 1
+    }
+    # Check if a gateway address was provided.
+    if echo $IPADDR | grep -q @
+    then
+        GATEWAY=$(echo $IPADDR | cut -d@ -f2)
+        IPADDR=$(echo $IPADDR | cut -d@ -f1)
+    else
+        GATEWAY=
+    fi
+fi
+
 # First step: determine type of first argument (bridge, physical interface...)
 if [ -d /sys/class/net/$IFNAME ]
 then
@@ -86,99 +112,55 @@ then
     fi
 else
     case "$IFNAME" in
-	br*)
-	    IFTYPE=bridge
-	    BRTYPE=linux
-	    ;;
-	*)
-	    echo "I do not know how to setup interface $IFNAME."
-	    exit 1
-	    ;;
+        br*)
+            IFTYPE=bridge
+            BRTYPE=linux
+            ;;
+        *)
+            echo "I do not know how to setup interface $IFNAME."
+            exit 1
+            ;;
     esac
 fi
 
-# Second step: find the guest (for now, we only support LXC containers)
+# Second step: find the guest (for now, we only support LXC containers).  Try to find a cgroup
+# matching exactly the provided name.  Use cgroup mount or docker to find a process within the
+# container, remember it in NSPID, and prepare to adjust its container's networking.
 while read dev mnt fstype options dump fsck
 do
     [ "$fstype" != "cgroup" ] && continue
     echo $options | grep -qw devices || continue
     CGROUPMNT=$mnt
+    (( VERB )) && echo "Found cgroup devices mount point: ${CGROUPMNT}"
 done < /proc/mounts
 
-[ "$CGROUPMNT" ] || {
-    echo "Could not locate cgroup mount point."
-    exit 1
-}
-
-# Try to find a cgroup matching exactly the provided name.
-N=$(find "$CGROUPMNT" -name "$GUESTNAME" | wc -l)
-case "$N" in
-    0)
-	# If we didn't find anything, try to lookup the container with Docker.
-	if which docker >/dev/null
-	then
-	    DOCKERID=$(docker inspect --format='{{.ID}}' $GUESTNAME)
-	    [ "$DOCKERID" = "<no value>" ] && {
-		echo "Container $GUESTNAME not found, and unknown to Docker."
-		exit 1
-	    }
-	    NN=$(find "$CGROUPMNT" -name "$DOCKERID" | wc -l)
-	    case "$NN" in
-		0)
-		    echo "Container $GUESTNAME doesn't seem to be running."
-		    exit 1
-		    ;;
-		1)
-		    GUESTNAME=$DOCKERID
-		    ;;
-		*)
-		    echo "Multiple cgroup entries for container $GUESTNAME."
-		    exit 1
-		    ;;
-	    esac
-	else
-	    echo "Container $GUESTNAME not found, and Docker not installed."
-	    exit 1
-	fi
-	;;
-    1)
-	true
-	;;
-    *)
-	echo "Found more than one container matching $GUESTNAME."
-	exit 1
-	;;
-esac
-
-if [ "$IPADDR" = "dhcp" ]; then
-    # We use udhcpc to obtain the DHCP lease, make sure it's installed.
-    which udhcpc >/dev/null || {
-	echo "You asked for DHCP; please install udhcpc first."
-	exit 1
-    }
-else
-    # Check if a subnet mask was provided.
-    echo $IPADDR | grep -q / || {
-	echo "The IP address should include a netmask."
-	echo "Maybe you meant $IPADDR/24 ?"
-	exit 1
-    }
-    # Check if a gateway address was provided.
-    if echo $IPADDR | grep -q @
-    then
-        GATEWAY=$(echo $IPADDR | cut -d@ -f2)
-        IPADDR=$(echo $IPADDR | cut -d@ -f1)
-    else
-        GATEWAY=
+if [ "$CGROUPMNT" ]; then
+    # OK, try to find NSPID using the cgroup devices mount point.  
+    CGROUPPATH=$( find "$CGROUPMNT" -name "$GUESTNAME" )
+    if (( $( echo -n "${CGROUPPATH}" | wc -l ) == 1 )); then
+        NSPID=$( head -n 1 ${CGROUPPATH}/tasks || true )
+        [ -z "$NSPID" ] && (( VERB )) && echo "Could not find a process using ${CGROUPPATH}"
     fi
 fi
-
-NSPID=$(head -n 1 $(find "$CGROUPMNT" -name "$GUESTNAME" | head -n 1)/tasks)
 if [ -z "$NSPID" ]; then
-    echo "Could not find a process inside container $GUESTNAME."
+    # If we didn't find anything using cgroups, try to lookup the container with Docker.  Normally,
+    # this'll be docker, but under some systems it's named docker.io
+    DOCKER=$( which docker 2>/dev/null || which docker.io 2>/dev/null )
+    if [ "$DOCKER" ]; then
+        NSPID=$( $DOCKER inspect --format='{{ .State.Pid }}' $GUESTNAME || true )
+        if [ -z "$NSPID" ] || [ "$NSPID" = "0" ] || [ "$NSPID" = "<no value>" ]; then
+            (( VERB )) && echo "Container $GUESTNAME not found, not running, or unknown to Docker."
+            NSPID=""
+        fi
+    else
+        (( VERB )) && echo "Container $GUESTNAME not found, and Docker not installed."
+    fi
+fi
+if [ -z "$NSPID" ]; then
+    echo "Could not find a process inside container ${GUESTNAME}."
     exit 1
 fi
-(( VERB )) && echo "Found container process PID $NSPID"
+(( VERB )) && echo "Found container ${GUESTNAME} process $NSPID"
 
 if ! mkdir -p /var/run/netns \
     || ! rm -f /var/run/netns/$NSPID \
@@ -189,7 +171,7 @@ fi
 
 # Check if we need to create a bridge.
 if [ "$IFTYPE" = "bridge" ] && [ ! -d /sys/class/net/$IFNAME ]; then
-    (ip link set $IFNAME type bridge > /dev/null 2>&1) || (brctl addbr $IFNAME)
+    ip link set $IFNAME type bridge >/dev/null 2>&1 || brctl addbr $IFNAME
     ip link set $IFNAME up
 fi
 
@@ -200,7 +182,7 @@ if [ "$IFTYPE" = "bridge" ]; then
     ip link add name $LOCAL_IFNAME type veth peer name $GUEST_IFNAME
     case "$BRTYPE" in
         linux)
-            (ip link set $LOCAL_IFNAME master $IFNAME > /dev/null 2>&1) || (brctl addif $IFNAME $LOCAL_IFNAME)
+            ip link set $LOCAL_IFNAME master $IFNAME >/dev/null 2>&1 || brctl addif $IFNAME $LOCAL_IFNAME
             ;;
         openvswitch)
             ovs-vsctl add-port $IFNAME $LOCAL_IFNAME
@@ -226,7 +208,7 @@ else
     (( VERB )) && echo "Bringing up dev $CONTAINER_IFNAME manually w/ IP address $IPADDR"
     ip netns exec $NSPID ip addr add $IPADDR dev $CONTAINER_IFNAME
     if [ "$GATEWAY" ]; then
-	ip netns exec $NSPID ip route delete default >/dev/null 2>&1 || true
+        ip netns exec $NSPID ip route delete default >/dev/null 2>&1 || true
     fi
     ip netns exec $NSPID ip link set $CONTAINER_IFNAME up
 fi
@@ -246,10 +228,9 @@ if [ "$GATEWAY" ]; then
 fi
 
 # Give our ARP neighbors a nudge about the new interface
-if which arping > /dev/null 2>&1
-then
+if which arping >/dev/null 2>&1; then
     IPADDR=$(echo $IPADDR | cut -d/ -f1) 
-    ip netns exec $NSPID arping -c 1 -A -I $CONTAINER_IFNAME $IPADDR > /dev/null 2>&1
+    ip netns exec $NSPID arping -c 1 -A -I $CONTAINER_IFNAME $IPADDR >/dev/null 2>&1
 else
     echo "Warning: arping not found; interface may not be immediately reachable"
 fi

--- a/pipework
+++ b/pipework
@@ -15,7 +15,7 @@ wrn() {
 err() {
     echo "$PROG ERROR: $*" >&2
 }
-
+TRIES=3
 CONTAINER_IFNAME=eth1
 while (( $# )); do
     case "$1" in
@@ -30,6 +30,12 @@ while (( $# )); do
             ;;
         --wait|-w)
             WAIT=1
+            ;;
+        --tries|-t)
+            # How many tries to find container?
+            shift
+            TRIES=$1
+            log "Try ${TRIES} times to find a container PID"
             ;;
         --route|-r)
             # Collect each route in another ${ROUTE[x]} entry
@@ -146,36 +152,40 @@ fi
 # Second step: find the guest (for now, we only support LXC containers).  Try to find a cgroup
 # matching exactly the provided name.  Use cgroup mount or docker to find a process within the
 # container, remember it in NSPID, and prepare to adjust its container's networking.
-while read dev mnt fstype options dump fsck
-do
-    [ "$fstype" != "cgroup" ] && continue
-    echo $options | grep -qw devices || continue
-    CGROUPMNT=$mnt
-    log "Found cgroup devices mount point: ${CGROUPMNT}"
-done < /proc/mounts
+NSPID=""
+for (( tries = 0; tries < TRIES && ${#NSPID} == 0; tries += 1 )); do
+    (( tries )) && sleep 1
+    while read dev mnt fstype options dump fsck
+    do
+        [ "$fstype" != "cgroup" ] && continue
+        echo $options | grep -qw devices || continue
+        CGROUPMNT=$mnt
+        log "Found cgroup devices mount point: ${CGROUPMNT}"
+    done < /proc/mounts
 
-if [ "$CGROUPMNT" ]; then
-    # OK, try to find NSPID using the cgroup devices mount point.  
-    CGROUPPATH=$( find "$CGROUPMNT" -name "$GUESTNAME" )
-    if (( $( echo -n "${CGROUPPATH}" | wc -l ) == 1 )); then
-        NSPID=$( head -n 1 ${CGROUPPATH}/tasks || true )
-        [ -z "$NSPID" ] && log "Could not find a process using ${CGROUPPATH}"
-    fi
-fi
-if [ -z "$NSPID" ]; then
-    # If we didn't find anything using cgroups, try to lookup the container with Docker.  Normally,
-    # this'll be docker, but under some systems it's named docker.io
-    DOCKER=$( which docker 2>/dev/null || which docker.io 2>/dev/null )
-    if [ "$DOCKER" ]; then
-        NSPID=$( $DOCKER inspect --format='{{ .State.Pid }}' $GUESTNAME || true )
-        if [ -z "$NSPID" ] || [ "$NSPID" = "0" ] || [ "$NSPID" = "<no value>" ]; then
-            log "Container $GUESTNAME not found, not running, or unknown to Docker."
-            NSPID=""
+    if [ "$CGROUPMNT" ]; then
+        # OK, try to find NSPID using the cgroup devices mount point.  
+        CGROUPPATH=$( find "$CGROUPMNT" -name "$GUESTNAME" )
+        if (( $( echo -n "${CGROUPPATH}" | wc -l ) == 1 )); then
+            NSPID=$( head -n 1 ${CGROUPPATH}/tasks || true )
+            [ -z "$NSPID" ] && log "Could not find a process using ${CGROUPPATH}"
         fi
-    else
-        log "Container $GUESTNAME not found, and Docker not installed."
     fi
-fi
+    if [ -z "$NSPID" ]; then
+        # If we didn't find anything using cgroups, try to lookup the container with Docker.  Normally,
+        # this'll be docker, but under some systems it's named docker.io
+        DOCKER=$( which docker 2>/dev/null || which docker.io 2>/dev/null )
+        if [ "$DOCKER" ]; then
+            NSPID=$( $DOCKER inspect --format='{{ .State.Pid }}' $GUESTNAME || true )
+            if [ -z "$NSPID" ] || [ "$NSPID" = "0" ] || [ "$NSPID" = "<no value>" ]; then
+                log "Container $GUESTNAME not found, not running, or unknown to Docker."
+                NSPID=""
+            fi
+        else
+            log "Container $GUESTNAME not found, and Docker not installed."
+        fi
+    fi
+done
 if [ -z "$NSPID" ]; then
     err "Could not find a process inside container ${GUESTNAME}."
     exit 1
@@ -251,7 +261,7 @@ fi
 # running arping within the container, it may not exist and we cannot check.  Note: on Debian/Ubuntu
 # you want iputils-arping (Thomas Habets), not arping (Alexey Kuznetsov)!
 IPADDR=$(echo $IPADDR | cut -d/ -f1) 
-if (( ARP )) && ! ip netns exec $NSPID arping -c 1 -A -I $CONTAINER_IFNAME $IPADDR >/dev/null 2>&1; then
-    wrn "arping failed; interface may not be immediately reachable"
+if (( ARP )) && ! ARPOUT=$( ip netns exec $NSPID arping -c 1 -A -I $CONTAINER_IFNAME $IPADDR 2>&1 ); then
+    wrn "arping failed; interface may not be immediately reachable: ${ARPOUT}"
 fi
 exit 0

--- a/pipework
+++ b/pipework
@@ -22,6 +22,9 @@ while (( $# )); do
         --trace|-x)
             set -x
             ;;
+        --arp|-a)
+            ARP=1
+            ;;
         --verbose|-v)
             VERB=1
             ;;
@@ -84,6 +87,7 @@ done
     echo "    -v|--verbose           (log activity)"
     echo "    -x|--trace             (trace all bash commands)"
     echo "    -h|--help              (print this help and exit)"
+    echo "    -a|--arp               (send a gratuitous arp to activate the new interface)"
     echo "  Any number of additional routes using the new interface may be specified:"
     echo "    -r|--route <network>   (route <network> via dev ${CONTAINER_IFNAME})"
     echo "  eg.  --route 224.0.0.0/4 (route multicast via ${CONTAINER_IFNAME})"
@@ -243,11 +247,11 @@ if [ "$GATEWAY" ]; then
     ip netns exec $NSPID ip route replace default via $GATEWAY
 fi
 
-# Give our ARP neighbors a nudge about the new interface
-if which arping >/dev/null 2>&1; then
-    IPADDR=$(echo $IPADDR | cut -d/ -f1) 
-    ip netns exec $NSPID arping -c 1 -A -I $CONTAINER_IFNAME $IPADDR >/dev/null 2>&1
-else
-    wrn "arping not found; interface may not be immediately reachable"
+# Give our ARP neighbors a nudge about the new interface; ignore arping failures; since we're
+# running arping within the container, it may not exist and we cannot check.  Note: on Debian/Ubuntu
+# you want iputils-arping (Thomas Habets), not arping (Alexey Kuznetsov)!
+IPADDR=$(echo $IPADDR | cut -d/ -f1) 
+if (( ARP )) && ! ip netns exec $NSPID arping -c 1 -A -I $CONTAINER_IFNAME $IPADDR >/dev/null 2>&1; then
+    wrn "arping failed; interface may not be immediately reachable"
 fi
 exit 0

--- a/pipework
+++ b/pipework
@@ -190,6 +190,7 @@ else
     ip netns exec $NSPID ip link set $CONTAINER_IFNAME up
     [ "$GATEWAY" ] && {
 	ip netns exec $NSPID ip route replace default via $GATEWAY
+	ip netns exec $NSPID ip route add 224.0.0.0/4 dev eth1
     }
 fi
 

--- a/pipework
+++ b/pipework
@@ -14,11 +14,12 @@ while (( $# )); do
             # Collect each route in another ${ROUTE[x]} entry
             shift
             ROUTE[${#ROUTE[*]}]=$1
+            (( VERB )) && echo "Route network: $1"
             ;;
         --interface|-i)
             shift
             CONTAINER_IFNAME=$1
-            (( VERB )) && echo "Guest i'face: $CONTAINER_IFNAME"
+            (( VERB )) && echo "Guest i'face:  $CONTAINER_IFNAME"
             ;;
         --*|-*) # unrecognized, eg. --help, -?
             HELP=1
@@ -27,16 +28,16 @@ while (( $# )); do
         *)
             if   [ -z "$IFNAME" ]; then
                 IFNAME=$1
-                (( VERB )) && echo "Host  i'face: $IFNAME"
+                (( VERB )) && echo "Host  i'face:  $IFNAME"
             elif [ -z "$GUESTNAME" ]; then
                 GUESTNAME=$1
-                (( VERB )) && echo "Guest name:   $GUESTNAME"
+                (( VERB )) && echo "Guest name:    $GUESTNAME"
             elif [ -z "$IPADDR" ]; then
                 IPADDR=$1
-                (( VERB )) && echo "IP  address:  $IPADDR"
+                (( VERB )) && echo "IP  address:   $IPADDR"
             elif [ -z "$MACADDR" ]; then
                 MACADDR=$1
-                (( VERB )) && echo "MAC address:  $MACADDR"
+                (( VERB )) && echo "MAC address:   $MACADDR"
             else
                 HELP=1
                 echo "Invalid argument: $1"
@@ -46,8 +47,6 @@ while (( $# )); do
     shift
 done
 
-[ "$IPADDR" ] || HELP=1
-
 [ "$WAIT" ] && {
   while ! grep -q ^1$ /sys/class/net/$CONTAINER_IFNAME/carrier 2>/dev/null
   do sleep 1
@@ -55,6 +54,7 @@ done
   exit 0
 }
 
+[ "$IPADDR" ] || HELP=1
 [ "$HELP" ] && {
     echo "Syntax:"
     echo "pipework <hostinterface> <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr]"
@@ -178,11 +178,14 @@ if [ -z "$NSPID" ]; then
     echo "Could not find a process inside container $GUESTNAME."
     exit 1
 fi
+(( VERB )) && echo "Found container process PID $NSPID"
 
-mkdir -p /var/run/netns
-rm -f /var/run/netns/$NSPID
-ln -s /proc/$NSPID/ns/net /var/run/netns/$NSPID
-
+if ! mkdir -p /var/run/netns \
+    || ! rm -f /var/run/netns/$NSPID \
+    || ! ln -s /proc/$NSPID/ns/net /var/run/netns/$NSPID; then
+    echo "Could not prepare to adjust container networking; run using sudo?"
+    exit 1
+fi
 
 # Check if we need to create a bridge.
 if [ "$IFTYPE" = "bridge" ] && [ ! -d /sys/class/net/$IFNAME ]; then

--- a/pipework
+++ b/pipework
@@ -3,6 +3,19 @@
 # Exit immediately, if any command fails without being captured by an if ...; then
 set -e
 
+# Logging
+PROG=$( basename $0 )
+VERB=
+log() {
+    (( VERB )) && echo "$PROG      : $*" >&2
+}
+wrn() {
+    echo "$PROG  WARN: $*" >&2
+}
+err() {
+    echo "$PROG ERROR: $*" >&2
+}
+
 CONTAINER_IFNAME=eth1
 while (( $# )); do
     case "$1" in
@@ -16,33 +29,33 @@ while (( $# )); do
             # Collect each route in another ${ROUTE[x]} entry
             shift
             ROUTE[${#ROUTE[*]}]=$1
-            (( VERB )) && echo "Route network: $1"
+            log "Route network: $1"
             ;;
         --interface|-i)
             shift
             CONTAINER_IFNAME=$1
-            (( VERB )) && echo "Guest i'face:  $CONTAINER_IFNAME"
+            log "Guest i'face:  $CONTAINER_IFNAME"
             ;;
         --*|-*) # unrecognized, eg. --help, -?
             HELP=1
-            echo "Invalid option: $1"
+            err "Invalid option: $1"
             ;;
         *)
             if   [ -z "$IFNAME" ]; then
                 IFNAME=$1
-                (( VERB )) && echo "Host  i'face:  $IFNAME"
+                log "Host i'face:   $IFNAME"
             elif [ -z "$GUESTNAME" ]; then
                 GUESTNAME=$1
-                (( VERB )) && echo "Guest name:    $GUESTNAME"
+                log "Guest name:    $GUESTNAME"
             elif [ -z "$IPADDR" ]; then
                 IPADDR=$1
-                (( VERB )) && echo "IP  address:   $IPADDR"
+                log "IP address:    $IPADDR"
             elif [ -z "$MACADDR" ]; then
                 MACADDR=$1
-                (( VERB )) && echo "MAC address:   $MACADDR"
+                log "MAC address:   $MACADDR"
             else
                 HELP=1
-                echo "Invalid argument: $1"
+                err "Invalid argument: $1"
             fi
             ;;
     esac
@@ -76,14 +89,13 @@ done
 if [ "$IPADDR" = "dhcp" ]; then
     # We use udhcpc to obtain the DHCP lease, make sure it's installed.
     which udhcpc >/dev/null || {
-        echo "You asked for DHCP; please install udhcpc first."
+        err "You asked for DHCP; please install udhcpc first."
         exit 1
     }
 else
     # Check if a subnet mask was provided.
     echo $IPADDR | grep -q / || {
-        echo "The IP address should include a netmask."
-        echo "Maybe you meant $IPADDR/24 ?"
+        err "The IP address should include a netmask; Maybe you meant $IPADDR/24 ?"
         exit 1
     }
     # Check if a gateway address was provided.
@@ -117,7 +129,7 @@ else
             BRTYPE=linux
             ;;
         *)
-            echo "I do not know how to setup interface $IFNAME."
+            err "I do not know how to setup interface $IFNAME."
             exit 1
             ;;
     esac
@@ -131,7 +143,7 @@ do
     [ "$fstype" != "cgroup" ] && continue
     echo $options | grep -qw devices || continue
     CGROUPMNT=$mnt
-    (( VERB )) && echo "Found cgroup devices mount point: ${CGROUPMNT}"
+    log "Found cgroup devices mount point: ${CGROUPMNT}"
 done < /proc/mounts
 
 if [ "$CGROUPMNT" ]; then
@@ -139,7 +151,7 @@ if [ "$CGROUPMNT" ]; then
     CGROUPPATH=$( find "$CGROUPMNT" -name "$GUESTNAME" )
     if (( $( echo -n "${CGROUPPATH}" | wc -l ) == 1 )); then
         NSPID=$( head -n 1 ${CGROUPPATH}/tasks || true )
-        [ -z "$NSPID" ] && (( VERB )) && echo "Could not find a process using ${CGROUPPATH}"
+        [ -z "$NSPID" ] && log "Could not find a process using ${CGROUPPATH}"
     fi
 fi
 if [ -z "$NSPID" ]; then
@@ -149,23 +161,23 @@ if [ -z "$NSPID" ]; then
     if [ "$DOCKER" ]; then
         NSPID=$( $DOCKER inspect --format='{{ .State.Pid }}' $GUESTNAME || true )
         if [ -z "$NSPID" ] || [ "$NSPID" = "0" ] || [ "$NSPID" = "<no value>" ]; then
-            (( VERB )) && echo "Container $GUESTNAME not found, not running, or unknown to Docker."
+            log "Container $GUESTNAME not found, not running, or unknown to Docker."
             NSPID=""
         fi
     else
-        (( VERB )) && echo "Container $GUESTNAME not found, and Docker not installed."
+        log "Container $GUESTNAME not found, and Docker not installed."
     fi
 fi
 if [ -z "$NSPID" ]; then
-    echo "Could not find a process inside container ${GUESTNAME}."
+    err "Could not find a process inside container ${GUESTNAME}."
     exit 1
 fi
-(( VERB )) && echo "Found container ${GUESTNAME} process $NSPID"
+log "Found container ${GUESTNAME} process $NSPID"
 
 if ! mkdir -p /var/run/netns \
     || ! rm -f /var/run/netns/$NSPID \
     || ! ln -s /proc/$NSPID/ns/net /var/run/netns/$NSPID; then
-    echo "Could not prepare to adjust container networking; run using sudo?"
+    err "Could not prepare to adjust container networking; run using sudo?"
     exit 1
 fi
 
@@ -202,10 +214,10 @@ ip link set $GUEST_IFNAME netns $NSPID
 ip netns exec $NSPID ip link set $GUEST_IFNAME name $CONTAINER_IFNAME
 [ "$MACADDR" ] && ip netns exec $NSPID ip link set $CONTAINER_IFNAME address $MACADDR
 if [ "$IPADDR" = "dhcp" ]; then
-    (( VERB )) && echo "Bringing up dev $CONTAINER_IFNAME using DHCP"
+    log "Bringing up dev $CONTAINER_IFNAME using DHCP"
     ip netns exec $NSPID udhcpc -qi $CONTAINER_IFNAME
 else
-    (( VERB )) && echo "Bringing up dev $CONTAINER_IFNAME manually w/ IP address $IPADDR"
+    log "Bringing up dev $CONTAINER_IFNAME manually w/ IP address $IPADDR"
     ip netns exec $NSPID ip addr add $IPADDR dev $CONTAINER_IFNAME
     if [ "$GATEWAY" ]; then
         ip netns exec $NSPID ip route delete default >/dev/null 2>&1 || true
@@ -217,13 +229,13 @@ fi
 # 224.0.0.0/4), establish them.  We must do this before any default route
 # via a gateway, in case it is over one of these new routes.
 for network in ${ROUTE[*]}; do
-    (( VERB )) && echo "Adding route for $network over dev $CONTAINER_IFNAME"
+    log "Adding route for $network over dev $CONTAINER_IFNAME"
     ip netns exec $NSPID ip route add $network dev $CONTAINER_IFNAME
 done
 
 # Finally, set up any default route via a gateway
 if [ "$GATEWAY" ]; then
-    (( VERB )) && echo "Setting default route via gateway $GATEWAY"
+    log "Setting default route via gateway $GATEWAY"
     ip netns exec $NSPID ip route replace default via $GATEWAY
 fi
 
@@ -232,6 +244,6 @@ if which arping >/dev/null 2>&1; then
     IPADDR=$(echo $IPADDR | cut -d/ -f1) 
     ip netns exec $NSPID arping -c 1 -A -I $CONTAINER_IFNAME $IPADDR >/dev/null 2>&1
 else
-    echo "Warning: arping not found; interface may not be immediately reachable"
+    wrn "arping not found; interface may not be immediately reachable"
 fi
 exit 0

--- a/pipework
+++ b/pipework
@@ -174,7 +174,7 @@ for (( tries = 0; tries < TRIES && ${#NSPID} == 0; tries += 1 )); do
     if [ -z "$NSPID" ]; then
         # If we didn't find anything using cgroups, try to lookup the container with Docker.  Normally,
         # this'll be docker, but under some systems it's named docker.io
-        DOCKER=$( which docker 2>/dev/null || which docker.io 2>/dev/null )
+        DOCKER=$( which docker 2>/dev/null )
         if [ "$DOCKER" ]; then
             NSPID=$( $DOCKER inspect --format='{{ .State.Pid }}' $GUESTNAME || true )
             if [ -z "$NSPID" ] || [ "$NSPID" = "0" ] || [ "$NSPID" = "<no value>" ]; then

--- a/pipework
+++ b/pipework
@@ -7,7 +7,7 @@ set -e
 PROG=$( basename $0 )
 VERB=
 log() {
-    (( VERB )) && echo "$PROG      : $*" >&2
+    if (( VERB )); then echo "$PROG      : $*" >&2; fi
 }
 wrn() {
     echo "$PROG  WARN: $*" >&2
@@ -19,6 +19,9 @@ err() {
 CONTAINER_IFNAME=eth1
 while (( $# )); do
     case "$1" in
+        --trace|-x)
+            set -x
+            ;;
         --verbose|-v)
             VERB=1
             ;;
@@ -78,7 +81,8 @@ done
     echo "pipework -w|--wait         (await interface appearance, within container)"
     echo "  The following options are available in any of the above commands:"
     echo "    -i|--interface <containerinterface> ..."
-    echo "    -v|--verbose ...       (log activity)"
+    echo "    -v|--verbose           (log activity)"
+    echo "    -x|--trace             (trace all bash commands)"
     echo "    -h|--help              (print this help and exit)"
     echo "  Any number of additional routes using the new interface may be specified:"
     echo "    -r|--route <network>   (route <network> via dev ${CONTAINER_IFNAME})"

--- a/pipework
+++ b/pipework
@@ -1,22 +1,52 @@
 #!/bin/bash
 set -e
 
-case "$1" in
-    --wait)
-      WAIT=1
-      ;;
-esac
+CONTAINER_IFNAME=eth1
+while (( $# )); do
+    case "$1" in
+        --verbose|-v)
+            VERB=1
+            ;;
+        --wait|-w)
+            WAIT=1
+            ;;
+        --route|-r)
+            # Collect each route in another ${ROUTE[x]} entry
+            shift
+            ROUTE[${#ROUTE[*]}]=$1
+            ;;
+        --interface|-i)
+            shift
+            CONTAINER_IFNAME=$1
+            (( VERB )) && echo "Guest i'face: $CONTAINER_IFNAME"
+            ;;
+        --*|-*) # unrecognized, eg. --help, -?
+            HELP=1
+            echo "Invalid option: $1"
+            ;;
+        *)
+            if   [ -z "$IFNAME" ]; then
+                IFNAME=$1
+                (( VERB )) && echo "Host  i'face: $IFNAME"
+            elif [ -z "$GUESTNAME" ]; then
+                GUESTNAME=$1
+                (( VERB )) && echo "Guest name:   $GUESTNAME"
+            elif [ -z "$IPADDR" ]; then
+                IPADDR=$1
+                (( VERB )) && echo "IP  address:  $IPADDR"
+            elif [ -z "$MACADDR" ]; then
+                MACADDR=$1
+                (( VERB )) && echo "MAC address:  $MACADDR"
+            else
+                HELP=1
+                echo "Invalid argument: $1"
+            fi
+            ;;
+    esac
+    shift
+done
 
-IFNAME=$1
-if [ "$2" == "-i" ]; then
-  CONTAINER_IFNAME=$3
-  shift 2
-else
-  CONTAINER_IFNAME=eth1
-fi
-GUESTNAME=$2
-IPADDR=$3
-MACADDR=$4
+[ "$IPADDR" ] || HELP=1
 
 [ "$WAIT" ] && {
   while ! grep -q ^1$ /sys/class/net/$CONTAINER_IFNAME/carrier 2>/dev/null
@@ -25,11 +55,18 @@ MACADDR=$4
   exit 0
 }
 
-[ "$IPADDR" ] || {
+[ "$HELP" ] && {
     echo "Syntax:"
-    echo "pipework <hostinterface> [-i containerinterface] <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr]"
-    echo "pipework <hostinterface> [-i containerinterface] <guest> dhcp [macaddr]"
-    echo "pipework --wait"
+    echo "pipework <hostinterface> <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr]"
+    echo "pipework <hostinterface> <guest> dhcp [macaddr]"
+    echo "pipework -w|--wait         (await interface appearance, within container)"
+    echo "  The following options are available in any of the above commands:"
+    echo "    -i|--interface <containerinterface> ..."
+    echo "    -v|--verbose ...       (log activity)"
+    echo "    -h|--help              (print this help and exit)"
+    echo "  Any number of additional routes using the new interface may be specified:"
+    echo "    -r|--route <network>   (route <network> via dev ${CONTAINER_IFNAME})"
+    echo "  eg.  --route 224.0.0.0/4 (route multicast via ${CONTAINER_IFNAME})"
     exit 1
 }
 
@@ -44,7 +81,8 @@ then
     then 
         IFTYPE=bridge
         BRTYPE=openvswitch
-    else IFTYPE=phys
+    else
+        IFTYPE=phys
     fi
 else
     case "$IFNAME" in
@@ -112,8 +150,7 @@ case "$N" in
 	;;
 esac
 
-if [ "$IPADDR" = "dhcp" ]
-then
+if [ "$IPADDR" = "dhcp" ]; then
     # We use udhcpc to obtain the DHCP lease, make sure it's installed.
     which udhcpc >/dev/null || {
 	echo "You asked for DHCP; please install udhcpc first."
@@ -137,10 +174,10 @@ else
 fi
 
 NSPID=$(head -n 1 $(find "$CGROUPMNT" -name "$GUESTNAME" | head -n 1)/tasks)
-[ "$NSPID" ] || {
+if [ -z "$NSPID" ]; then
     echo "Could not find a process inside container $GUESTNAME."
     exit 1
-}
+fi
 
 mkdir -p /var/run/netns
 rm -f /var/run/netns/$NSPID
@@ -148,13 +185,13 @@ ln -s /proc/$NSPID/ns/net /var/run/netns/$NSPID
 
 
 # Check if we need to create a bridge.
-[ $IFTYPE = bridge ] && [ ! -d /sys/class/net/$IFNAME ] && {
+if [ "$IFTYPE" = "bridge" ] && [ ! -d /sys/class/net/$IFNAME ]; then
     (ip link set $IFNAME type bridge > /dev/null 2>&1) || (brctl addbr $IFNAME)
     ip link set $IFNAME up
-}
+fi
 
 # If it's a bridge, we need to create a veth pair
-[ $IFTYPE = bridge ] && {
+if [ "$IFTYPE" = "bridge" ]; then
     LOCAL_IFNAME=pl$NSPID$CONTAINER_IFNAME
     GUEST_IFNAME=pg$NSPID$CONTAINER_IFNAME
     ip link add name $LOCAL_IFNAME type veth peer name $GUEST_IFNAME
@@ -167,31 +204,42 @@ ln -s /proc/$NSPID/ns/net /var/run/netns/$NSPID
             ;;
     esac
     ip link set $LOCAL_IFNAME up
-}
+fi
 
 # If it's a physical interface, create a macvlan subinterface
-[ $IFTYPE = phys ] && {
+if [ "$IFTYPE" = "phys" ]; then
     GUEST_IFNAME=ph$NSPID$CONTAINER_IFNAME
     ip link add link $IFNAME dev $GUEST_IFNAME type macvlan mode bridge
     ip link set $IFNAME up
-}
+fi
 
 ip link set $GUEST_IFNAME netns $NSPID
 ip netns exec $NSPID ip link set $GUEST_IFNAME name $CONTAINER_IFNAME
 [ "$MACADDR" ] && ip netns exec $NSPID ip link set $CONTAINER_IFNAME address $MACADDR
-if [ "$IPADDR" = "dhcp" ]
-then
+if [ "$IPADDR" = "dhcp" ]; then
+    (( VERB )) && echo "Bringing up dev $CONTAINER_IFNAME using DHCP"
     ip netns exec $NSPID udhcpc -qi $CONTAINER_IFNAME
 else
+    (( VERB )) && echo "Bringing up dev $CONTAINER_IFNAME manually w/ IP address $IPADDR"
     ip netns exec $NSPID ip addr add $IPADDR dev $CONTAINER_IFNAME
     [ "$GATEWAY" ] && {
 	ip netns exec $NSPID ip route delete default >/dev/null 2>&1 && true
     }
     ip netns exec $NSPID ip link set $CONTAINER_IFNAME up
-    [ "$GATEWAY" ] && {
-	ip netns exec $NSPID ip route replace default via $GATEWAY
-	ip netns exec $NSPID ip route add 224.0.0.0/4 dev eth1
-    }
+fi
+
+# If any routes were specified for the new container interface (eg. --route
+# 224.0.0.0/4), establish them.  We must do this before any default route
+# via a gateway, in case it is over one of these new routes.
+for network in ${ROUTE[*]}; do
+    (( VERB )) && echo "Adding route for $network over dev $CONTAINER_IFNAME"
+    ip netns exec $NSPID ip route add $network dev $CONTAINER_IFNAME
+done
+
+# Finally, set up any default route via a gateway
+if [ "$GATEWAY" ]; then
+    (( VERB )) && echo "Setting default route via gateway $GATEWAY"
+    ip netns exec $NSPID ip route replace default via $GATEWAY
 fi
 
 # Give our ARP neighbors a nudge about the new interface


### PR DESCRIPTION
The parsing of arguments has been improved, adding support for long- and short-form options.

New -v|--verbose option allows pipework to print a play-by-play of argument parsing and what it is doing, to assist in diagnosis when things go unexpectedly.

The new -r|--route <network> option allows specifying one or more new routes in the container using the new interface.  This is useful, for example, to set up multicast to use the new interface, eg. --route 224.0.0.0/4 

Also cleaned up some of the conditionals and variable quoting.
