### PR TITLE
Shorten interface names to avoid too long names

### DIFF
--- a/pipework
+++ b/pipework
@@ -155,8 +155,8 @@ ln -s /proc/$NSPID/ns/net /var/run/netns/$NSPID
 
 # If it's a bridge, we need to create a veth pair
 [ $IFTYPE = bridge ] && {
-    LOCAL_IFNAME=vethl$NSPID$CONTAINER_IFNAME
-    GUEST_IFNAME=vethg$NSPID$CONTAINER_IFNAME
+    LOCAL_IFNAME=pl$NSPID$CONTAINER_IFNAME
+    GUEST_IFNAME=pg$NSPID$CONTAINER_IFNAME
     ip link add name $LOCAL_IFNAME type veth peer name $GUEST_IFNAME
     case "$BRTYPE" in
         linux)
@@ -171,7 +171,7 @@ ln -s /proc/$NSPID/ns/net /var/run/netns/$NSPID
 
 # If it's a physical interface, create a macvlan subinterface
 [ $IFTYPE = phys ] && {
-    GUEST_IFNAME=macvlan$NSPID$CONTAINER_IFNAME
+    GUEST_IFNAME=ph$NSPID$CONTAINER_IFNAME
     ip link add link $IFNAME dev $GUEST_IFNAME type macvlan mode bridge
     ip link set $IFNAME up
 }


### PR DESCRIPTION
This "fixes" #28
