### PR TITLE
Fix typo in warning message

### DIFF
--- a/pipework
+++ b/pipework
@@ -199,6 +199,6 @@ then
     IPADDR=$(echo $IPADDR | cut -d/ -f1) 
     ip netns exec $NSPID arping -c 1 -A -I $CONTAINER_IFNAME $IPADDR > /dev/null 2>&1
 else
-    echo "Warning: arping not found; interface may not be immediately recheable"
+    echo "Warning: arping not found; interface may not be immediately reachable"
 fi
 exit 0


### PR DESCRIPTION
Fixed a typo in the 'arping not found' warning message
