### PR TITLE
Update deprecated docker flags to new format

### DIFF
--- a/pipework
+++ b/pipework
@@ -79,7 +79,7 @@ case "$N" in
 	# If we didn't find anything, try to lookup the container with Docker.
 	if which docker >/dev/null
 	then
-	    DOCKERID=$(docker inspect -format='{{.ID}}' $GUESTNAME)
+	    DOCKERID=$(docker inspect --format='{{.ID}}' $GUESTNAME)
 	    [ "$DOCKERID" = "<no value>" ] && {
 		echo "Container $GUESTNAME not found, and unknown to Docker."
 		exit 1


### PR DESCRIPTION
Docker 0.9 introduced a new format for flags, deprecating long flags with single dash prefix.

This commit gets rid of the following warning from Docker:

```
Warning: '-format'  is deprecated, it will be removed soon. See usage.
```
