### PR TITLE
cgroup file relocation

### DIFF
--- a/pipework
+++ b/pipework
@@ -73,7 +73,7 @@ done < /proc/mounts
 }
 
 # Try to find a cgroup matching exactly the provided name.
-N=$(find "$CGROUPMNT" -name "$GUESTNAME" | wc -l)
+N=$( (find "$CGROUPMNT" -name "$GUESTNAME"; find "$CGROUPMNT" -name "docker-$DOCKERID.scope" ) | wc -l)
 case "$N" in
     0)
 	# If we didn't find anything, try to lookup the container with Docker.
@@ -84,7 +84,7 @@ case "$N" in
 		echo "Container $GUESTNAME not found, and unknown to Docker."
 		exit 1
 	    }
-	    NN=$(find "$CGROUPMNT" -name "$DOCKERID" | wc -l)
+            NN=$( (find "$CGROUPMNT" -name "$DOCKERID"; find "$CGROUPMNT" -name "docker-$DOCKERID.scope") | wc -l)
 	    case "$NN" in
 		0)
 		    echo "Container $GUESTNAME doesn't seem to be running."
@@ -136,7 +136,7 @@ else
     fi
 fi
 
-NSPID=$(head -n 1 $(find "$CGROUPMNT" -name "$GUESTNAME" | head -n 1)/tasks)
+NSPID=$(head -n 1 $( (find "$CGROUPMNT" -name "$GUESTNAME"; find "$CGROUPMNT" -name "docker-$GUESTNAME.scope"; ) | head -n 1)/tasks)
 [ "$NSPID" ] || {
     echo "Could not find a process inside container $GUESTNAME."
     exit 1


### PR DESCRIPTION
on my box the location of the cgroup directory has changed from $CID/ to docker-$CID.scope/, like this:
$ find /sys/fs/cgroup/devices -name "docker-*"
/sys/fs/cgroup/devices/system.slice/docker-bfac064c180363bdfe406a563f6b2367fedcb580cae623a7de73bc73b7e78c88.scope

this patch lets me use pipework with these location changes.

Docker version 0.10.0-dev, build 566d49c
Linux 3.13.7-1-aufs_friendly #1 SMP PREEMPT Wed Mar 26 22:01:25 MDT 2014 x86_64 GNU/Linux
