### PR TITLE
Adding another way to flush ARP cache

### DIFF
--- a/pipework
+++ b/pipework
@@ -200,4 +200,11 @@ then
 else
     echo "Warning: arping not found; interface may not be immediately reachable"
 fi
+
+# Flush ARP cache on route to gateway
+if [ "$GATEWAY" ] && which ping > /dev/null 2>&1; 
+then
+    ip netns exec $NSPID ping -I $CONTAINER_IFNAME -c 1 $GATEWAY
+fi
+
 exit 0

--- a/pipework
+++ b/pipework
@@ -204,7 +204,7 @@ fi
 # Flush ARP cache on route to gateway
 if [ "$GATEWAY" ] && which ping > /dev/null 2>&1; 
 then
-    ip netns exec $NSPID ping -I $CONTAINER_IFNAME -c 1 $GATEWAY
+    ip netns exec $NSPID ping -I $CONTAINER_IFNAME -c 1 $GATEWAY > /dev/null 2>&1
 fi
 
 exit 0


### PR DESCRIPTION
This is a workaround for the case I've described [here](http://serverfault.com/questions/599799/ip-address-reuse-on-macvlan-devices). I've added `ping` to force gateway to update ARP cache entry for IP of macvlan interface. This update is done on first IP packet with new MAC:IP address pair, looks like just `arping` is not enough. 
