### PR TITLE
missing dev parameter to set mac  address

### DIFF
--- a/pipework
+++ b/pipework
@@ -175,7 +175,7 @@ ln -s /proc/$NSPID/ns/net /var/run/netns/$NSPID
 
 ip link set $GUEST_IFNAME netns $NSPID
 ip netns exec $NSPID ip link set $GUEST_IFNAME name $CONTAINER_IFNAME
-[ "$MACADDR" ] && ip netns exec $NSPID ip link set $CONTAINER_IFNAME address $MACADDR
+[ "$MACADDR" ] && ip netns exec $NSPID ip link set dev $CONTAINER_IFNAME address $MACADDR
 if [ "$IPADDR" = "dhcp" ]
 then
     [ $DHCP_CLIENT = "udhcpc"  ] && ip netns exec $NSPID $DHCP_CLIENT -qi $CONTAINER_IFNAME


### PR DESCRIPTION
The "dev" parameter was missing when setting the mac address.

Just tried on Ubuntu 14.04. 

Maybe some other host do not require the dev parameter.
