### PR TITLE
Inherit MTU from the bridge to prevent fragmentation

### DIFF
--- a/pipework
+++ b/pipework
@@ -183,11 +183,12 @@ ln -s /proc/$NSPID/ns/net /var/run/netns/$NSPID
     ip link set $IFNAME up
 }
 
+MTU=$(ip link show $IFNAME | awk '{print $5}')
 # If it's a bridge, we need to create a veth pair
 [ $IFTYPE = bridge ] && {
     LOCAL_IFNAME=pl$NSPID$CONTAINER_IFNAME
     GUEST_IFNAME=pg$NSPID$CONTAINER_IFNAME
-    ip link add name $LOCAL_IFNAME type veth peer name $GUEST_IFNAME
+    ip link add name $LOCAL_IFNAME mtu $MTU type veth peer name $GUEST_IFNAME mtu $MTU
     case "$BRTYPE" in
         linux)
             (ip link set $LOCAL_IFNAME master $IFNAME > /dev/null 2>&1) || (brctl addif $IFNAME $LOCAL_IFNAME)
@@ -203,14 +204,14 @@ ln -s /proc/$NSPID/ns/net /var/run/netns/$NSPID
 [ $IFTYPE = phys ] && {
     [ "$VLAN" ] && {
         [ ! -d /sys/class/net/$IFNAME.$VLAN ] && {
-            ip link add link $IFNAME name $IFNAME.$VLAN type vlan id $VLAN
+            ip link add link $IFNAME name $IFNAME.$VLAN mtu $MTU type vlan id $VLAN
         }
 
         ip link set $IFNAME up
         IFNAME=$IFNAME.$VLAN
     }
     GUEST_IFNAME=ph$NSPID$CONTAINER_IFNAME
-    ip link add link $IFNAME dev $GUEST_IFNAME type macvlan mode bridge
+    ip link add link $IFNAME dev $GUEST_IFNAME mtu $MTU type macvlan mode bridge
     ip link set $IFNAME up
 }
 


### PR DESCRIPTION
Otherwise, performs drops 2x due to MTU mismatch.
