### PR TITLE
Allow for subinterfaces

### DIFF
--- a/pipework
+++ b/pipework
@@ -42,7 +42,7 @@ fi
 }
 
 # First step: determine type of first argument (bridge, physical interface...)
-if [ -d /sys/class/net/$IFNAME ]
+if [ -d /sys/class/net/$(echo $IFNAME|cut -f1 -d:) ]
 then
     if [ -d /sys/class/net/$IFNAME/bridge ]
     then


### PR DESCRIPTION
There's probably a better way to go about this, but...

Pipework will work well using sub-interfaces (eth0:1, eth0:2, etc) but when you run it as such, the current checking method does not detect it as a valid interface and quits. This patch will parse anything to the left of the colon in a sub-interface to get past the check. Everything else still works the same. My example code:

./pipework eth0:1 $(docker run -d -t -i --name=test --privileged=true ubunutu /sbin/my_init -- bash -l) 192.168.10.55/24

That would fail under the current code, but is allowed under this patch and creates a sub-interface eth0:1 on the host machine, along with eth1 of the same IP in the container. 

Like I said, probably a better way to do it, but this worked for me. Thanks for a great project!
