### PR TITLE
add some test for reset network from host to prevent crash

### DIFF
--- a/pipework
+++ b/pipework
@@ -184,6 +184,17 @@ ln -s /proc/$NSPID/ns/net /var/run/netns/$NSPID
 }
 
 MTU=$(ip link show $IFNAME | awk '{print $5}')
+
+# cifexist means Container Interface is Existed or not
+if ip netns exec $NSPID ip link show $CONTAINER_IFNAME > /dev/null 2>&1
+then
+    # Container Interface Existed
+    cifexist=1
+else
+    # Container Interface not Existed
+    cifexist=0
+fi
+
 # If it's a bridge, we need to create a veth pair
 [ $IFTYPE = bridge ] && {
     LOCAL_IFNAME="v${CONTAINER_IFNAME}pl${NSPID}"
@@ -211,13 +222,22 @@ MTU=$(ip link show $IFNAME | awk '{print $5}')
         IFNAME=$IFNAME.$VLAN
     }
     GUEST_IFNAME=ph$NSPID$CONTAINER_IFNAME
-    ip link add link $IFNAME dev $GUEST_IFNAME mtu $MTU type macvlan mode bridge
+    [ $cifexist = 0 ] && ip link add link $IFNAME dev $GUEST_IFNAME mtu $MTU type macvlan mode bridge
     ip link set $IFNAME up
 }
 
-ip link set $GUEST_IFNAME netns $NSPID
-ip netns exec $NSPID ip link set $GUEST_IFNAME name $CONTAINER_IFNAME
+if [ $cifexist = 0 ]
+then
+    # create interface if not exist
+    ip link set $GUEST_IFNAME netns $NSPID
+    ip netns exec $NSPID ip link set $GUEST_IFNAME name $CONTAINER_IFNAME
+else
+    # shutdown interface if exist
+    ip netns exec $NSPID ip link set $CONTAINER_IFNAME down
+fi
 [ "$MACADDR" ] && ip netns exec $NSPID ip link set dev $CONTAINER_IFNAME address $MACADDR
+# clear ip address before setting new one
+ip netns exec $NSPID ip addr flush dev $CONTAINER_IFNAME
 if [ "$IPADDR" = "dhcp" ]
 then
     [ $DHCP_CLIENT = "udhcpc"  ] && ip netns exec $NSPID $DHCP_CLIENT -qi $CONTAINER_IFNAME -x hostname:$GUESTNAME


### PR DESCRIPTION
before:

```
docker run -itd --net none --name test busybox:latest
pipework eth0 -i eth0 192.168.0.100/24@192.168.0.1
pipework eth0 -i eth0 192.168.0.101/24@192.168.0.1
```

segmentation fault

---

after:

```
docker run -itd --net none --name test busybox:latest
pipework eth0 -i eth0 192.168.0.100/24@192.168.0.1
pipework eth0 -i eth0 192.168.0.101/24@192.168.0.1
```

continue to do more jobs

---

development environment

```
Ubuntu 14.04.1 LTS
Linux 3.13.0-35-generic #62-Ubuntu SMP Fri Aug 15 01:58:42 UTC 2014 x86_64
Docker version 1.2.0, build fa7b24f
```
