### PR TITLE
kill dhclient after get ip address to prevent device be used after container close

### DIFF
--- a/pipework
+++ b/pipework
@@ -221,7 +221,13 @@ ip netns exec $NSPID ip link set $GUEST_IFNAME name $CONTAINER_IFNAME
 if [ "$IPADDR" = "dhcp" ]
 then
     [ $DHCP_CLIENT = "udhcpc"  ] && ip netns exec $NSPID $DHCP_CLIENT -qi $CONTAINER_IFNAME -x hostname:$GUESTNAME
-    [ $DHCP_CLIENT = "dhclient"  ] && ip netns exec $NSPID $DHCP_CLIENT $CONTAINER_IFNAME -H $GUESTNAME
+    if [ $DHCP_CLIENT = "dhclient"  ]
+    then
+        # kill dhclient after get ip address to prevent device be used after container close
+        ip netns exec $NSPID $DHCP_CLIENT -pf "/var/run/dhclient.$NSPID.pid" $CONTAINER_IFNAME
+        kill "$(cat "/var/run/dhclient.$NSPID.pid")"
+        rm "/var/run/dhclient.$NSPID.pid"
+    fi
     [ $DHCP_CLIENT = "dhcpcd"  ] && ip netns exec $NSPID $DHCP_CLIENT -q $CONTAINER_IFNAME -h $GUESTNAME
 else
     ip netns exec $NSPID ip addr add $IPADDR dev $CONTAINER_IFNAME


### PR DESCRIPTION
The situation is: when I use dhcp in container network, it will run a dhclient process and take the network resource (eth0). Then, I close and remove the container from host, the network resource will not be released.

My patch will kill the dhclient process after it got the ip address, so the network resource will not be taken for long time.

Anyone has the better solution?

---

development environment

```
Ubuntu 14.04.1 LTS
Linux 3.13.0-35-generic #62-Ubuntu SMP Fri Aug 15 01:58:42 UTC 2014 x86_64
Docker version 1.2.0, build fa7b24f
```
