### PR TITLE
Prevent manipulating the same net namespace twice

### DIFF
--- a/pipework
+++ b/pipework
@@ -173,7 +173,11 @@ fi
 }
 
 [ ! -d /var/run/netns ] && mkdir -p /var/run/netns
-[ -f /var/run/netns/$NSPID ] && rm -f /var/run/netns/$NSPID
+[ -f /var/run/netns/$NSPID ] && {
+        echo "/var/run/netns/$NSPID exists, aborting"
+        exit 1
+}
+
 ln -s /proc/$NSPID/ns/net /var/run/netns/$NSPID
 
 

--- a/pipework
+++ b/pipework
@@ -173,6 +173,10 @@ fi
 }
 
 [ ! -d /var/run/netns ] && mkdir -p /var/run/netns
+
+#cleanup /var/run/netns/ directory for next checks -- remove stale links
+find -L /var/run/netns/ -type l -delete
+
 [ -f /var/run/netns/$NSPID ] && {
         echo "/var/run/netns/$NSPID exists, aborting"
         exit 1
@@ -247,6 +251,4 @@ else
     echo "Warning: arping not found; interface may not be immediately reachable"
 fi
 
-# Remove NSPID to avoid `ip netns` catch it.
-[ -f /var/run/netns/$NSPID ] && rm -f /var/run/netns/$NSPID
 exit 0


### PR DESCRIPTION
In an effort to prevent https://github.com/jpetazzo/pipework/issues/79. This is a bit limiting and perhaps there should be a force-recreate option, but preventing the segfault in the first place was my main concern. Thoughts?