### PR TITLE
Add a route to the gateway when hosted on a different subnet

### DIFF
--- a/pipework
+++ b/pipework
@@ -236,6 +236,8 @@ else
     }
     ip netns exec $NSPID ip link set $CONTAINER_IFNAME up
     [ "$GATEWAY" ] && {
+	ip netns exec $NSPID ip route get $GATEWAY >/dev/null 2>&1 || \
+		ip netns exec $NSPID ip route add $GATEWAY/32 dev $CONTAINER_IFNAME
 	ip netns exec $NSPID ip route replace default via $GATEWAY
     }
 fi


### PR DESCRIPTION
  use case: a number of dedicated server providers offer failover
  ips. In that case the gateway that needs to be used is derived from
  the server main ip address which is usually hosted on another subnet.

  see for instance (section 2.4) :
    http://forum.online.net/index.php?/topic/4437-all-about-failover-ips-beginners-guide/
