### PR TITLE
Add support for virtual IPoIB interfaces (ipoib subinterface) & partition keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ The following will attach a container to ib0
 
 The following will do the same but connect it to ib0 with pkey 8001
 
-    pipework ib0 $(docker run -d hpcworker) 10.10.10.10/24 @8001
+    pipework ib0 $CONTAINERID 10.10.10.10/24 @8001
 
  
 <a name="cleanup"/>

--- a/README.md
+++ b/README.md
@@ -319,13 +319,19 @@ If the ovs bridge doesn't exist, it will be automatically created
 <a name="infiniband"/>
 ### Support Infiniband IPoIB
 
-Passing an IPoIB interface to a container is supported.  However, the entire device
-is moved into the network namespace of the container.  It therefore becomes hidden
-from the host.  
+Passing an IPoIB interface to a container is supported.  The ipoib device is
+created as a virtual device.  It's similar to a macvlan but for ipoib devices.
+Also supported are partition keys.
 
-To provide infiniband to multiple containers, use SR-IOV and pass
-the virtual function devices to the containers.
-  
+The following will attach a container to ib0
+
+    pipework ib0 $CONTAINERID 10.10.10.10/24
+
+The following will do the same but connect it to ib0 with pkey 8001
+
+    pipework ib0 $(docker run -d hpcworker) 10.10.10.10/24 @8001
+
+ 
 <a name="cleanup"/>
 ### Cleanup
 

--- a/README.md
+++ b/README.md
@@ -319,8 +319,8 @@ If the ovs bridge doesn't exist, it will be automatically created
 <a name="infiniband"/>
 ### Support Infiniband IPoIB
 
-Passing an IPoIB interface to a container is supported.  The ipoib device is
-created as a virtual device.  It's similar to a macvlan but for ipoib devices.
+Passing an IPoIB interface to a container is supported.  The IPoIB device is
+created as a virtual device.  It's similar to a macvlan but for IPoIB devices.
 Also supported are partition keys.
 
 The following will attach a container to ib0

--- a/pipework
+++ b/pipework
@@ -256,7 +256,7 @@ MTU=$(ip link show $IFNAME | awk '{print $5}')
         PKEY="pkey $PKEY"
     }
     ip link add link $IFNAME name $GUEST_IFNAME type ipoib $PKEY
-	IFNAME=$GUEST_IFNAME
+    IFNAME=$GUEST_IFNAME
 }
 
 ip link set $GUEST_IFNAME netns $NSPID

--- a/pipework
+++ b/pipework
@@ -51,8 +51,8 @@ if [ -z "$WAIT" ]; then
         elif [ $(cat /sys/class/net/$IFNAME/type) -eq 32 ]; # Infiniband IPoIB interface type 32
         then
             IFTYPE=ipoib
-			PKEY=$VLAN
-            # The IPoIB kernel module is fussy, set device name to ib0 if not overridden
+            PKEY=$VLAN
+            # The IPoIB kernel module is fussy, set device name to ib0 if not specified
             CONTAINER_IFNAME=${CONTAINER_IFNAME:-ib0}
         else IFTYPE=phys
         fi
@@ -246,16 +246,12 @@ MTU=$(ip link show $IFNAME | awk '{print $5}')
     ip link set $IFNAME up
 }
 
-# If it's an ipoib interface, create a virtual ipoib interface
-# Note: if no container interface name was specified, pipework will default to ib0
-# Note: no macvlan subinterface or ethernet bridge can be created against an 	
-# ipoib interface. Infiniband is not ethernet. ipoib is an IP layer for it and has it's own type
+# If it's an IPoIB interface, create a virtual IPoIB interface (IPoIB equivalent of a macvlan)
 [ $IFTYPE = ipoib ] && {
     GUEST_IFNAME=$IFNAME.$NSPID
 
-    # Infiniband doesn't have VLANs but Partition Keys.  PKEYs are similar to VLANs, but not quite the same
+    # If a partition key is provided, use it
     [ "$PKEY" ] && {
-        # If a Partition Key is set, use it
         GUEST_IFNAME=$IFNAME.$PKEY.$NSPID
         PKEY="pkey $PKEY"
     }

--- a/pipework
+++ b/pipework
@@ -259,9 +259,8 @@ MTU=$(ip link show $IFNAME | awk '{print $5}')
         GUEST_IFNAME=$IFNAME.$PKEY.$NSPID
         PKEY="pkey $PKEY"
     }
-
     ip link add link $IFNAME name $GUEST_IFNAME type ipoib $PKEY
-    ip link set $IFNAME up
+	IFNAME=$GUEST_IFNAME
 }
 
 ip link set $GUEST_IFNAME netns $NSPID
@@ -291,13 +290,16 @@ else
     }
 fi
 
-# Give our ARP neighbors a nudge about the new interface
-if which arping > /dev/null 2>&1
-then
-    IPADDR=$(echo $IPADDR | cut -d/ -f1)
-    ip netns exec $NSPID arping -c 1 -A -I $CONTAINER_IFNAME $IPADDR > /dev/null 2>&1 || true
-else
-    echo "Warning: arping not found; interface may not be immediately reachable"
+if [ $IFTYPE != "ipoib" ] 
+then   
+    # Give our ARP neighbors a nudge about the new interface
+    if which arping > /dev/null 2>&1
+    then
+        IPADDR=$(echo $IPADDR | cut -d/ -f1)
+        ip netns exec $NSPID arping -c 1 -A -I $CONTAINER_IFNAME $IPADDR > /dev/null 2>&1 || true
+    else
+        echo "Warning: arping not found; interface may not be immediately reachable"
+    fi
 fi
 
 # Remove NSPID to avoid `ip netns` catch it.

--- a/pipework
+++ b/pipework
@@ -247,6 +247,9 @@ MTU=$(ip link show $IFNAME | awk '{print $5}')
 }
 
 # If it's an ipoib interface, create a virtual ipoib interface
+# Note: if no container interface name was specified, pipework will default to ib0
+# Note: no macvlan subinterface or ethernet bridge can be created against an 	
+# ipoib interface. Infiniband is not ethernet. ipoib is an IP layer for it and has it's own type
 [ $IFTYPE = ipoib ] && {
     GUEST_IFNAME=$IFNAME.$NSPID
 

--- a/pipework
+++ b/pipework
@@ -51,6 +51,7 @@ if [ -z "$WAIT" ]; then
         elif [ $(cat /sys/class/net/$IFNAME/type) -eq 32 ]; # Infiniband IPoIB interface type 32
         then
             IFTYPE=ipoib
+			PKEY=$VLAN
             # The IPoIB kernel module is fussy, set device name to ib0 if not overridden
             CONTAINER_IFNAME=${CONTAINER_IFNAME:-ib0}
         else IFTYPE=phys
@@ -230,15 +231,6 @@ MTU=$(ip link show $IFNAME | awk '{print $5}')
     ip link set $LOCAL_IFNAME up
 }
 
-# Note: if no container interface name was specified, pipework will default to ib0
-# Note: no macvlan subinterface or ethernet bridge can be created against an 
-# ipoib interface. Infiniband is not ethernet. ipoib is an IP layer for it.
-# To provide additional ipoib interfaces to containers use SR-IOV and pipework 
-# to assign them.
-[ $IFTYPE = ipoib ] && {
-  GUEST_IFNAME=$CONTAINER_IFNAME
-}
-
 # If it's a physical interface, create a macvlan subinterface
 [ $IFTYPE = phys ] && {
     [ "$VLAN" ] && {
@@ -251,6 +243,21 @@ MTU=$(ip link show $IFNAME | awk '{print $5}')
     }
     GUEST_IFNAME=ph$NSPID$CONTAINER_IFNAME
     ip link add link $IFNAME dev $GUEST_IFNAME mtu $MTU type macvlan mode bridge
+    ip link set $IFNAME up
+}
+
+# If it's an ipoib interface, create a virtual ipoib interface
+[ $IFTYPE = ipoib ] && {
+    GUEST_IFNAME=$IFNAME.$NSPID
+
+    # Infiniband doesn't have VLANs but Partition Keys.  PKEYs are similar to VLANs, but not quite the same
+    [ "$PKEY" ] && {
+        # If a Partition Key is set, use it
+        GUEST_IFNAME=$IFNAME.$PKEY.$NSPID
+        PKEY="pkey $PKEY"
+    }
+
+    ip link add link $IFNAME name $GUEST_IFNAME type ipoib $PKEY
     ip link set $IFNAME up
 }
 


### PR DESCRIPTION
Add support for virtual IPoIB interfaces.  These are similar to ethernet macvlan.  It prevents the device being moved only into a single container.
Also added is support for Infiniband Partition Keys (which are similar to the ethernet VLAN).

Use like the following:

    pipework ib0 $CONTAINERID 10.10.10.1/24
    pipework ib0 $CONTAINERID 10.10.10.1/24 @8001  # for PKEY 8001 which must be set up in your subnet manager.

I've also updated the Readme for reflect the changes.