### PR TITLE
Adding routes establishement on the internal interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Pipework uses cgroups and namespace and works with "plain" LXC containers
 * [Peeking inside the private network](#peeking_inside)  
 * [Setting container internal interface](#setting_internal)  
 * [Using a different netmask](#different_netmask)  
+* [Setting a route on the internal interface](#route_internal)
 * [Setting a default gateway](#default_gateway)  
 * [Connect a container to a local physical interface](#local_physical)  
 * [Let the Docker host communicate over macvlan interfaces](#macvlan)  
@@ -155,6 +156,17 @@ This can be automated by Pipework, by adding the gateway address
 after the IP address and subnet mask:
 
     pipework br1 $CONTAINERID 192.168.4.25/20@192.168.4.1
+
+
+<a name="route_internal"/>
+### Setting routes on the internal interface
+
+In you add more than one internal interface, you may want to add other routes than the default one. 
+This could be performed by adding network and masks after the gateway (comma-separated)
+
+    pipework br1 $CONTAINERID 192.168.4.25/20@192.168.4.1 192.168.5.0/25,192.168.6.0/24
+
+Please note that the last added internal interface will take the default route
 
 
 <a name="local_physical"/>

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Pipework uses cgroups and namespace and works with "plain" LXC containers
 * [Peeking inside the private network](#peeking_inside)  
 * [Setting container internal interface](#setting_internal)  
 * [Using a different netmask](#different_netmask)  
-* [Setting a route on the internal interface](#route_internal)
 * [Setting a default gateway](#default_gateway)  
+* [Setting routes on the internal interface](#route_internal) 
 * [Connect a container to a local physical interface](#local_physical)  
 * [Let the Docker host communicate over macvlan interfaces](#macvlan)  
 * [Wait for the network to be ready](#wait_ready)  
@@ -161,7 +161,7 @@ after the IP address and subnet mask:
 <a name="route_internal"/>
 ### Setting routes on the internal interface
 
-In you add more than one internal interface, you may want to add other routes than the default one. 
+In you add more than one internal interface, or perform specific use-cases, you may want to add other routes than the default one. 
 This could be performed by adding network and masks after the gateway (comma-separated)
 
     pipework br1 $CONTAINERID 192.168.4.25/20@192.168.4.1 192.168.5.0/25,192.168.6.0/24

--- a/pipework
+++ b/pipework
@@ -18,7 +18,15 @@ fi
 
 GUESTNAME=$2
 IPADDR=$3
-MACADDR=$4
+
+if echo $4 | grep -q :
+then
+  MACADDR=$4
+  ROUTES=$5
+else
+  MACADDR=
+  ROUTES=$4
+fi
 
 if echo $MACADDR | grep -q @
 then
@@ -31,6 +39,7 @@ fi
 [ "$IPADDR" ] || [ "$WAIT" ] || {
     echo "Syntax:"
     echo "pipework <hostinterface> [-i containerinterface] <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr][@vlan]"
+    echo "pipework <hostinterface> [-i containerinterface] <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr][@vlan] [route1,route2,...]"
     echo "pipework <hostinterface> [-i containerinterface] <guest> dhcp [macaddr][@vlan]"
     echo "pipework --wait [-i containerinterface]"
     exit 1
@@ -275,9 +284,15 @@ else
     }
     ip netns exec $NSPID ip link set $CONTAINER_IFNAME up
     [ "$GATEWAY" ] && {
-	ip netns exec $NSPID ip route get $GATEWAY >/dev/null 2>&1 || \
-		ip netns exec $NSPID ip route add $GATEWAY/32 dev $CONTAINER_IFNAME
-	ip netns exec $NSPID ip route replace default via $GATEWAY
+        ip netns exec $NSPID ip route get $GATEWAY >/dev/null 2>&1 || \
+                ip netns exec $NSPID ip route add $GATEWAY/32 dev $CONTAINER_IFNAME
+        ip netns exec $NSPID ip route replace default via $GATEWAY
+    [ "$ROUTES" ] && {
+        ROUTES=`echo $ROUTES | tr ',' ' '`;
+        for ROUTE in $ROUTES; do
+            ip netns exec $NSPID ip route add $ROUTE via $GATEWAY dev $CONTAINER_IFNAME
+        done
+    }
     }
 fi
 


### PR DESCRIPTION
Added one argument to pipework allowing to specify routes in the container. 
Use-cases : 
* More than one internal interface
* Multicast routing
* ...