### PR TITLE
Allow local interface name to be specified

### DIFF
--- a/pipework
+++ b/pipework
@@ -18,6 +18,11 @@ if [ "$2" = "-i" ]; then
   shift 2
 fi
 
+if [ "$2" = "-l" ]; then
+  LOCAL_IFNAME=$3
+  shift 2
+fi
+
 GUESTNAME=$2
 IPADDR=$3
 MACADDR=$4
@@ -35,8 +40,8 @@ esac
 
 [ "$IPADDR" ] || [ "$WAIT" ] || {
   echo "Syntax:"
-  echo "pipework <hostinterface> [-i containerinterface] <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr][@vlan]"
-  echo "pipework <hostinterface> [-i containerinterface] <guest> dhcp [macaddr][@vlan]"
+  echo "pipework <hostinterface> [-i containerinterface] [-l localinterfacename] <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr][@vlan]"
+  echo "pipework <hostinterface> [-i containerinterface] [-l localinterfacename] <guest> dhcp [macaddr][@vlan]"
   echo "pipework --wait [-i containerinterface]"
   exit 1
 }
@@ -233,7 +238,9 @@ ln -s "/proc/$NSPID/ns/net" "/var/run/netns/$NSPID"
 MTU=$(ip link show "$IFNAME" | awk '{print $5}')
 # If it's a bridge, we need to create a veth pair
 [ "$IFTYPE" = bridge ] && {
-  LOCAL_IFNAME="v${CONTAINER_IFNAME}pl${NSPID}"
+  if [ -z "$LOCAL_IFNAME" ]; then
+    LOCAL_IFNAME="v${CONTAINER_IFNAME}pl${NSPID}"
+  fi
   GUEST_IFNAME="v${CONTAINER_IFNAME}pg${NSPID}"
   ip link add name "$LOCAL_IFNAME" mtu "$MTU" type veth peer name "$GUEST_IFNAME" mtu "$MTU"
   case "$BRTYPE" in

--- a/pipework
+++ b/pipework
@@ -248,7 +248,9 @@ MTU=$(ip link show "$IFNAME" | awk '{print $5}')
       (ip link set "$LOCAL_IFNAME" master "$IFNAME" > /dev/null 2>&1) || (brctl addif "$IFNAME" "$LOCAL_IFNAME")
       ;;
     openvswitch)
-      ovs-vsctl add-port "$IFNAME" "$LOCAL_IFNAME" ${VLAN:+tag="$VLAN"}
+      if ! ovs-vsctl list-ports "$IFNAME" | grep -q "$LOCAL_IFNAME"; then
+        ovs-vsctl add-port "$IFNAME" "$LOCAL_IFNAME" ${VLAN:+tag="$VLAN"}
+      fi
       ;;
   esac
   ip link set "$LOCAL_IFNAME" up

--- a/pipework
+++ b/pipework
@@ -242,6 +242,16 @@ MTU=$(ip link show "$IFNAME" | awk '{print $5}')
     LOCAL_IFNAME="v${CONTAINER_IFNAME}pl${NSPID}"
   fi
   GUEST_IFNAME="v${CONTAINER_IFNAME}pg${NSPID}"
+  # Does the link already exist?
+  if ip link show "$LOCAL_IFNAME" >/dev/null 2>&1; then
+    # link exists, is it in use?
+    if ip link show "$LOCAL_IFNAME" up | grep -q "UP"; then
+      echo "Link $LOCAL_IFNAME exists and is up"
+      exit 1
+    fi
+    # delete the link so we can re-add it afterwards
+    ip link del "$LOCAL_IFNAME"
+  fi
   ip link add name "$LOCAL_IFNAME" mtu "$MTU" type veth peer name "$GUEST_IFNAME" mtu "$MTU"
   case "$BRTYPE" in
     linux)


### PR DESCRIPTION
Maybe I missed something, but it doesn't look as though the current schema for local interface name generation is chosen for any specific reason. This option allows the local interface name to be set to something meaningful (for instance the name of the container to which the interface belongs).

I haven't built in any error checking (i.e. checking if the interface to be specified already exists), this could be done in a further step if this change is seen as useful.