### PR TITLE
Option to namespace physical and SR-IOV interfaces without using macvlan

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,14 @@ interfaces eth2 and eth3, using specific (public) IP addresses. Easy!
     pipework eth3 $(docker run -d hipache /usr/sbin/hipache) 107.22.140.5/24
 
 Note that this will use `macvlan` subinterfaces, so you can actually put
-multiple containers on the same physical interface.
+multiple containers on the same physical interface.  If you don't want to
+virtualize the interface, you can use the `--direct-phys` option to namespace
+an interface exclusively to a container without using a macvlan bridge.
 
+    pipework --direct-phys eth1 $CONTAINERID 192.168.1.2/24
+
+This is useful for assigning SR-IOV VFs to containers, but be aware of added
+latency when using the NIC to switch packets between containers on the same host.
 
 <a name="macvlan"/>
 ### Let the Docker host communicate over macvlan interfaces

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # Pipework
 
+## CHANGES FROM jpetazzo/pipework
+
+This version accepts a --direct-phys option to namespace a physical interface
+exclusively to a container, without using a macvlan bridge.  Preliminary tests
+have shown significantly less overhead and higher throughput if the use case
+indicates assigning an interface to one container.  Example:
+
+pipework --direct-phys eth1 <containerID> 10.10.1.2/24
+
+Note that this will move the interface into a network namespace whose identifier
+will be deleted afterward.  The simplest way to get the interface back when you're
+done with the container is just to reboot.
+
+## END CHANGES 
+
 **_Software-Defined Networking for Linux Containers_**
 
 Pipework lets you connect together containers in arbitrarily complex scenarios. 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,5 @@
 # Pipework
 
-## CHANGES FROM jpetazzo/pipework
-
-This version accepts a --direct-phys option to namespace a physical interface
-exclusively to a container, without using a macvlan bridge.  Preliminary tests
-have shown significantly less overhead and higher throughput if the use case
-indicates assigning an interface to one container.  Example:
-
-pipework --direct-phys eth1 <containerID> 10.10.1.2/24
-
-Note that this will move the interface into a network namespace whose identifier
-will be deleted afterward.  The simplest way to get the interface back when you're
-done with the container is just to reboot.
-
-## END CHANGES 
-
 **_Software-Defined Networking for Linux Containers_**
 
 Pipework lets you connect together containers in arbitrarily complex scenarios. 

--- a/pipework
+++ b/pipework
@@ -7,6 +7,10 @@ case "$1" in
   --wait)
     WAIT=1
     ;;
+  --direct-phys)
+    DIRECT_PHYS=1
+    shift
+    ;;
 esac
 
 IFNAME=$1
@@ -257,8 +261,14 @@ MTU=$(ip link show "$IFNAME" | awk '{print $5}')
     ip link set "$IFNAME" up
     IFNAME=$IFNAME.$VLAN
   }
-  GUEST_IFNAME=ph$NSPID$CONTAINER_IFNAME
-  ip link add link "$IFNAME" dev "$GUEST_IFNAME" mtu "$MTU" type macvlan mode bridge
+
+  if [ ! -z "$DIRECT_PHYS" ]; then
+    GUEST_IFNAME=$IFNAME
+  else
+    GUEST_IFNAME=ph$NSPID$CONTAINER_IFNAME
+    ip link add link "$IFNAME" dev "$GUEST_IFNAME" mtu "$MTU" type macvlan mode bridge
+  fi
+
   ip link set "$IFNAME" up
 }
 


### PR DESCRIPTION
I've found in a lot of experiments that I need to directly assign an interface to a container, both with SR-IOV and with normal physical interfaces.  This change adds an optional --direct-phys first argument to skip the creation of a macvlan.  If someone is working on a getopts version of this script, I'd be happy to add it there.