### PR TITLE
it is an alternative way to get the pid

### DIFF
--- a/pipework
+++ b/pipework
@@ -209,7 +209,11 @@ if [ "$DOCKERPID" ]; then
 else
   NSPID=$(head -n 1 "$(find "$CGROUPMNT" -name "$GUESTNAME" | head -n 1)/tasks")
   [ "$NSPID" ] || {
-    die 1 "Could not find a process inside container $GUESTNAME."
+    # it is an alternative way to get the pid
+    NSPID=$(lxc-info -n  "$GUESTNAME" | grep PID | grep -Eo '[0-9]+')
+    [ "$NSPID" ] || {
+      die 1 "Could not find a process inside container $GUESTNAME."
+    }
   }
 fi
 


### PR DESCRIPTION
Some times /sys/fs/cgroup/devices/lxc/{GUESTNAME}/tasks  file is empty
so this part of code doesn't work correct
```
NSPID=$(head -n 1 "$(find "$CGROUPMNT" -name "$GUESTNAME" | head -n 1)/tasks")
```


and it causes the errors like this:
```
Could not find a process inside container {GUESTNAME}.
```
or
```
There was an error executing ["sudo", "/usr/local/bin/vagrant-lxc-wrapper", "pipework", "vlxcbr0", "{GUESTNAME}", "192.168.2.104/24"]

```
I don't sure which is the root cause of the problem, but this approach works for me
