### PR TITLE
DHCP option separator is colon, not semi-colon

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ It works fine on plain old wired Ethernet, though.
 ### DHCP Options
 
 You can specify extra DHCP options to be passed to the DHCP client
-by adding them with a semi-colon. For instance:
+by adding them with a colon. For instance:
 
     pipework eth1 $CONTAINERID dhcp:-f
 


### PR DESCRIPTION
Tiny text fix, but was bugging me!