### PR TITLE
Add VLAN support for linux bridges

### DIFF
--- a/pipework
+++ b/pipework
@@ -140,11 +140,11 @@ case "$N" in
   0)
     # If we didn't find anything, try to lookup the container with Docker.
     if installed docker; then
-      RETRIES=3
+      RETRIES=10
       while [ "$RETRIES" -gt 0 ]; do
         DOCKERPID=$(docker inspect --format='{{ .State.Pid }}' "$GUESTNAME")
         [ "$DOCKERPID" != 0 ] && break
-        sleep 1
+        sleep 2
         RETRIES=$((RETRIES - 1))
       done
 

--- a/pipework
+++ b/pipework
@@ -115,10 +115,6 @@ CONTAINER_IFNAME=${CONTAINER_IFNAME:-eth1}
   exit 0
 }
 
-[ "$IFTYPE" = bridge ] && [ "$BRTYPE" = linux ] && [ "$VLAN" ] && {
-  die 1 "VLAN configuration currently unsupported for Linux bridge."
-}
-
 [ "$IFTYPE" = ipoib ] && [ "$MACADDR" ] && {
   die 1 "MACADDR configuration unsupported for IPoIB interfaces."
 }
@@ -291,6 +287,12 @@ MTU=$(ip link show "$IFNAME" | awk '{print $5}')
 
 ip link set "$GUEST_IFNAME" netns "$NSPID"
 ip netns exec "$NSPID" ip link set "$GUEST_IFNAME" name "$CONTAINER_IFNAME"
+[ "$IFTYPE" = bridge ] && [ "$BRTYPE" = linux ] && [ "$VLAN" ] && {
+    ip netns exec "$NSPID" vconfig add "$CONTAINER_IFNAME" "$VLAN"
+    ip netns exec "$NSPID" ip link set dev "$CONTAINER_IFNAME" up
+    ip netns exec "$NSPID" ip link set dev "$CONTAINER_IFNAME.$VLAN" up
+    CONTAINER_IFNAME="$CONTAINER_IFNAME.$VLAN"
+}
 [ "$MACADDR" ] && ip netns exec "$NSPID" ip link set dev "$CONTAINER_IFNAME" address "$MACADDR"
 
 # When using any of the DHCP methods, we start a DHCP client in the


### PR DESCRIPTION
Currently, pipework does not support setting up vlan interfaces when using linux bridges. This is necessary when you need VLANs on a non OVS supported scenario. This patch adds basic support by allowing trunk interfaces to be added a VLAN interface using the vconfig tool.
