### PR TITLE
Add support for child IPoIB interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Pipework uses cgroups and namespace and works with "plain" LXC containers
 - [Specify a custom MAC address](#specify-a-custom-mac-address)
 - [Virtual LAN (VLAN)](#virtual-lan-vlan)
 - [Support Open vSwitch](#support-open-vswitch)
-- [Support Infiniband IPoIB](#support-infiniband-ipoib)
+- [Support InfiniBand IPoIB](#support-infiniband-ipoib)
 - [Cleanup](#cleanup)
 - [About this file](#about-this-file)
 
@@ -129,7 +129,7 @@ By default pipework creates a new interface `eth1` inside the container. In case
 
 `pipework br1 -i eth2 ...`
 
-**Note:**: for infiniband IPoIB interfaces, the default interface name is `ib0` and not `eth1`.
+**Note:**: for InfiniBand IPoIB interfaces, the default interface name is `ib0` and not `eth1`.
 
 
 ### Setting host interface name ##
@@ -373,15 +373,20 @@ If you want to attach a container to the Open vSwitch bridge, no problem.
 If the ovs bridge doesn't exist, it will be automatically created
 
 
-### Support Infiniband IPoIB
+### Support InfiniBand IPoIB
 
-Passing an IPoIB interface to a container is supported.  However, the entire device
-is moved into the network namespace of the container.  It therefore becomes hidden
-from the host.  
+Passing an IPoIB interface to a container is supported.  The IPoIB device is
+created as a virtual device, similarly to how macvlan devices work.  The
+interface also supports setting a partition key for the created virtual device.
 
-To provide infiniband to multiple containers, use SR-IOV and pass
-the virtual function devices to the containers.
-  
+The following will attach a container to ib0
+
+    pipework ib0 $CONTAINERID 10.10.10.10/24
+
+The following will do the same but connect it to ib0 with pkey 0x8001
+
+    pipework ib0 $CONTAINERID 10.10.10.10/24 @8001
+
 
 ### Cleanup
 

--- a/pipework
+++ b/pipework
@@ -76,10 +76,11 @@ if [ -z "$WAIT" ]; then
     elif installed ovs-vsctl && ovs-vsctl list-br|grep -q "^${IFNAME}$"; then
       IFTYPE=bridge
       BRTYPE=openvswitch
-    elif [ "$(cat "/sys/class/net/$IFNAME/type")" -eq 32 ]; then # Infiniband IPoIB interface type 32
+    elif [ "$(cat "/sys/class/net/$IFNAME/type")" -eq 32 ]; then # InfiniBand IPoIB interface type 32
       IFTYPE=ipoib
       # The IPoIB kernel module is fussy, set device name to ib0 if not overridden
       CONTAINER_IFNAME=${CONTAINER_IFNAME:-ib0}
+      PKEY=$VLAN
     else IFTYPE=phys
     fi
   else
@@ -270,15 +271,6 @@ MTU=$(ip link show "$IFNAME" | awk '{print $5}')
   ip link set "$LOCAL_IFNAME" up
 }
 
-# Note: if no container interface name was specified, pipework will default to ib0
-# Note: no macvlan subinterface or ethernet bridge can be created against an 
-# ipoib interface. Infiniband is not ethernet. ipoib is an IP layer for it.
-# To provide additional ipoib interfaces to containers use SR-IOV and pipework 
-# to assign them.
-[ "$IFTYPE" = ipoib ] && {
-  GUEST_IFNAME=$CONTAINER_IFNAME
-}
-
 # If it's a physical interface, create a macvlan subinterface
 [ "$IFTYPE" = phys ] && {
   [ "$VLAN" ] && {
@@ -290,6 +282,25 @@ MTU=$(ip link show "$IFNAME" | awk '{print $5}')
   }
   GUEST_IFNAME=ph$NSPID$CONTAINER_IFNAME
   ip link add link "$IFNAME" dev "$GUEST_IFNAME" mtu "$MTU" type macvlan mode bridge
+  ip link set "$IFNAME" up
+}
+
+# If it's an IPoIB interface, create a virtual IPoIB interface (the IPoIB
+# equivalent of a macvlan device)
+#
+# Note: no macvlan subinterface nor Ethernet bridge can be created on top of an
+# IPoIB interface. InfiniBand is not Ethernet. IPoIB is an IP layer on top of
+# InfiniBand, without an intermediate Ethernet layer.
+[ "$IFTYPE" = ipoib ] && {
+  GUEST_IFNAME="${IFNAME}.${NSPID}"
+
+  # If a partition key is provided, use it
+  [ "$PKEY" ] && {
+    GUEST_IFNAME="${IFNAME}.${PKEY}.${NSPID}"
+    PKEY="pkey 0x$PKEY"
+  }
+
+  ip link add link "$IFNAME" name "$GUEST_IFNAME" type ipoib $PKEY
   ip link set "$IFNAME" up
 }
 


### PR DESCRIPTION
This prevents moving the selected IPoIB interface from the host to the
container. Instead, create a child interface and only move that
interface.

The code is based on the code @hookenz wrote (see [pull request](https://github.com/jpetazzo/pipework/pull/108)).



