### PR TITLE
Setup Adapter Type in Vagrantfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ the following to the config for the same effect:
 
 ```Ruby
 config.vm.provider "virtualbox" do |v|
+  v.customize ['modifyvm', :id, '--nictype1', 'Am79C973']
   v.customize ['modifyvm', :id, '--nicpromisc1', 'allow-all']
 end
 ```


### PR DESCRIPTION
`Am79C973` is the type id for **PCnet-FAST III**

<img width="415" alt="screenshot 2015-09-03 12 55 56" src="https://cloud.githubusercontent.com/assets/865677/9650862/6e16de0a-523b-11e5-8279-072d52b8a142.png">
