### PR TITLE
Enable support for a custom generated mac address

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,16 @@ In other words, if your MAC address is `?X:??:??:??:??:??`, `X` should
 be `2`, `6`, `a`, or `e`. You can check [Wikipedia](
 http://en.wikipedia.org/wiki/MAC_address) if you want even more details.
 
+If you want a consistent MAC address across container restarts, but don't want to have to keep track of the messy MAC addresses, ask pipework to generate an address for you based on a specified string, e.g. the hostname. This guarantees a consistent MAC address:
+
+    pipework eth0 <container> dhcp U:<some_string>
+
+pipework will take *some_string* and hash it using MD5. It will then take the first 40 bits of the MD5 hash, add those to the locally administered prefix of 0x02, and create a unique MAC address.
+
+For example, if your unique string is "myhost.foo.com", then the MAC address will **always** be `02:72:6c:cd:9b:8d`.
+
+This is particularly useful in the case of DHCP, where you might want the container to stop and start, but always get the same address. Most DHCP servers will keep giving you a consistent IP address if the MAC address is consistent.
+
 **Note:**  Setting the MAC address of an IPoIB interface is not supported.
 
 ### Virtual LAN (VLAN)

--- a/pipework
+++ b/pipework
@@ -38,6 +38,17 @@ case "$MACADDR" in
     ;;
 esac
 
+# did they ask to generate a custom MACADDR?
+# generate the unique string
+case "$MACADDR" in
+  U:*)
+    macunique="${MACADDR#*:}"
+    # now generate a 48-bit hash string from $macunique
+    MACADDR=$(echo $macunique|md5sum|sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')
+   ;;
+esac
+
+
 [ "$IPADDR" ] || [ "$WAIT" ] || {
   echo "Syntax:"
   echo "pipework <hostinterface> [-i containerinterface] [-l localinterfacename] <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr][@vlan]"


### PR DESCRIPTION
Adds support for generated mac address with uniqueness.

If the mac address follows the pattern with `U:<string>`, then it will use `<string>` to generate a unique mac address in the Locally Administered range. This allows people to have unique and repeatable mac addresses, without needing to manually manage and enter them.

Most common use case, of course, is to use hostname.