### PR TITLE
Add support for routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Pipework uses cgroups and namespace and works with "plain" LXC containers
 - [DHCP Options](#dhcp-options)
 - [Specify a custom MAC address](#specify-a-custom-mac-address)
 - [Virtual LAN (VLAN)](#virtual-lan-vlan)
+- [Control routes](#routes)
 - [Support Open vSwitch](#support-open-vswitch)
 - [Support Infiniband IPoIB](#support-infiniband-ipoib)
 - [Cleanup](#cleanup)
@@ -361,6 +362,18 @@ ovs0 and attach the container to VLAN ID 10.
 
     pipework ovsbr0 $(docker run -d zerorpcworker) dhcp @10
 
+### Control Routes
+
+If you want to add/delete/replace routes in the container, you can run any iproute2 route command via pipework.
+
+All you have to do is set the interface to be `route`, followed by the container ID or name, followed by the route command.
+
+Here are some examples.
+
+    pipework route $CONTAINERID add 10.0.5.6/24 via 192.168.2.1
+    pipework route $CONTAINERID replace default via 10.2.3.5.78
+
+Everything after the container ID (or name) will be run as an argument to `ip route` inside the container's namespace. Use the iproute2 man page.
 
 ### Support Open vSwitch
 

--- a/pipework
+++ b/pipework
@@ -26,6 +26,7 @@ fi
 GUESTNAME=$2
 IPADDR=$3
 MACADDR=$4
+ROUTECMD=${*:3}
 
 case "$MACADDR" in
   *@*)
@@ -42,6 +43,7 @@ esac
   echo "Syntax:"
   echo "pipework <hostinterface> [-i containerinterface] [-l localinterfacename] <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr][@vlan]"
   echo "pipework <hostinterface> [-i containerinterface] [-l localinterfacename] <guest> dhcp [macaddr][@vlan]"
+  echo "pipework route <guest> <route_command>"
   echo "pipework --wait [-i containerinterface]"
   exit 1
 }
@@ -94,6 +96,9 @@ if [ -z "$WAIT" ]; then
         fi
         IFTYPE=bridge
         BRTYPE=openvswitch
+        ;;
+      route*)
+        IFTYPE=route
         ;;
       *) die 1 "I do not know how to setup interface $IFNAME." ;;
     esac
@@ -163,39 +168,42 @@ case "$N" in
   *) die 1 "Found more than one container matching $GUESTNAME." ;;
 esac
 
-case "$IPADDR" in
-  # Let's check first if the user asked for DHCP allocation.
-  dhcp|dhcp:*)
-    # Use Docker-specific strategy to run the DHCP client
-    # from the busybox image, in the network namespace of
-    # the container.
-    if ! [ "$DOCKERPID" ]; then
-      warn "You asked for a Docker-specific DHCP method."
-      warn "However, $GUESTNAME doesn't seem to be a Docker container."
-      warn "Try to replace 'dhcp' with another option?"
-      die 1 "Aborting."
-    fi
-    DHCP_CLIENT=${IPADDR%%:*}
-    ;;
-  udhcpc|udhcpc:*|dhcpcd|dhcpcd:*|dhclient|dhclient:*)
-    DHCP_CLIENT=${IPADDR%%:*}
-    if ! installed "$DHCP_CLIENT"; then
-      die 1 "You asked for DHCP client $DHCP_CLIENT, but I can't find it."
-    fi
-    ;;
-  # Alright, no DHCP? Then let's see if we have a subnet *and* gateway.
-  */*@*)
-    GATEWAY="${IPADDR#*@}" GATEWAY="${GATEWAY%%@*}"
-    IPADDR="${IPADDR%%@*}"
-    ;;
-  # No gateway? We need at least a subnet, anyway!
-  */*) : ;;
-  # ... No? Then stop right here.
-  *)
-    warn "The IP address should include a netmask."
-    die 1 "Maybe you meant $IPADDR/24 ?"
-    ;;
-esac
+# only check IPADDR if we are not in a route mode
+[ "$IFTYPE" != route ] && {
+  case "$IPADDR" in
+    # Let's check first if the user asked for DHCP allocation.
+    dhcp|dhcp:*)
+      # Use Docker-specific strategy to run the DHCP client
+      # from the busybox image, in the network namespace of
+      # the container.
+      if ! [ "$DOCKERPID" ]; then
+        warn "You asked for a Docker-specific DHCP method."
+        warn "However, $GUESTNAME doesn't seem to be a Docker container."
+        warn "Try to replace 'dhcp' with another option?"
+        die 1 "Aborting."
+      fi
+      DHCP_CLIENT=${IPADDR%%:*}
+      ;;
+    udhcpc|udhcpc:*|dhcpcd|dhcpcd:*|dhclient|dhclient:*)
+      DHCP_CLIENT=${IPADDR%%:*}
+      if ! installed "$DHCP_CLIENT"; then
+        die 1 "You asked for DHCP client $DHCP_CLIENT, but I can't find it."
+      fi
+      ;;
+    # Alright, no DHCP? Then let's see if we have a subnet *and* gateway.
+    */*@*)
+      GATEWAY="${IPADDR#*@}" GATEWAY="${GATEWAY%%@*}"
+      IPADDR="${IPADDR%%@*}"
+      ;;
+    # No gateway? We need at least a subnet, anyway!
+    */*) : ;;
+    # ... No? Then stop right here.
+    *)
+      warn "The IP address should include a netmask."
+      die 1 "Maybe you meant $IPADDR/24 ?"
+      ;;
+  esac
+}
 
 # If a DHCP method was specified, extract the DHCP options.
 if [ "$DHCP_CLIENT" ]; then
@@ -239,7 +247,7 @@ ln -s "/proc/$NSPID/ns/net" "/var/run/netns/$NSPID"
   }
 }
 
-MTU=$(ip link show "$IFNAME" | awk '{print $5}')
+[ "$IFTYPE" != "route" ] && MTU=$(ip link show "$IFNAME" | awk '{print $5}')
 # If it's a bridge, we need to create a veth pair
 [ "$IFTYPE" = bridge ] && {
   if [ -z "$LOCAL_IFNAME" ]; then
@@ -293,61 +301,65 @@ MTU=$(ip link show "$IFNAME" | awk '{print $5}')
   ip link set "$IFNAME" up
 }
 
-ip link set "$GUEST_IFNAME" netns "$NSPID"
-ip netns exec "$NSPID" ip link set "$GUEST_IFNAME" name "$CONTAINER_IFNAME"
-[ "$MACADDR" ] && ip netns exec "$NSPID" ip link set dev "$CONTAINER_IFNAME" address "$MACADDR"
+# if its a route interface, run the route command else set up the interface
+if [ "$IFTYPE" = route ]; then
+  ip netns exec "$NSPID" ip route $ROUTECMD
+else 
+  ip link set "$GUEST_IFNAME" netns "$NSPID"
+  ip netns exec "$NSPID" ip link set "$GUEST_IFNAME" name "$CONTAINER_IFNAME"
+  [ "$MACADDR" ] && ip netns exec "$NSPID" ip link set dev "$CONTAINER_IFNAME" address "$MACADDR"
 
-# When using any of the DHCP methods, we start a DHCP client in the
-# network namespace of the container. With the 'dhcp' method, the
-# client used is taken from the Docker busybox image (therefore
-# requiring no specific client installed on the host). Other methods
-# use a locally installed client.
-case "$DHCP_CLIENT" in
-  dhcp)
-    docker run -d --net container:$GUESTNAME --cap-add NET_ADMIN \
-           busybox udhcpc -i "$CONTAINER_IFNAME" -x "hostname:$GUESTNAME" \
-           $DHCP_OPTIONS \
-           >/dev/null
-    ;;
-  udhcpc)
-    ip netns exec "$NSPID" "$DHCP_CLIENT" -qi "$CONTAINER_IFNAME" \
-                                          -x "hostname:$GUESTNAME" \
-                                          $DHCP_OPTIONS
-    ;;
-  dhclient)
-    ip netns exec "$NSPID" "$DHCP_CLIENT" "$CONTAINER_IFNAME" \
-                                          -pf "/var/run/dhclient.$NSPID.pid" \
-                                          -H "$GUESTNAME" \
-                                          $DHCP_OPTIONS
-    # kill dhclient after get ip address to prevent device be used after container close
-    kill "$(cat "/var/run/dhclient.$NSPID.pid")"
-    rm "/var/run/dhclient.$NSPID.pid"
-    ;;
-  dhcpcd)
-    ip netns exec "$NSPID" "$DHCP_CLIENT" -q "$CONTAINER_IFNAME" -h "$GUESTNAME"
-    ;;
-  "")
-    ip netns exec "$NSPID" ip addr add "$IPADDR" dev "$CONTAINER_IFNAME"
-    [ "$GATEWAY" ] && {
-      ip netns exec "$NSPID" ip route delete default >/dev/null 2>&1 && true
-    }
-    ip netns exec "$NSPID" ip link set "$CONTAINER_IFNAME" up
-    [ "$GATEWAY" ] && {
-      ip netns exec "$NSPID" ip route get "$GATEWAY" >/dev/null 2>&1 || \
-      ip netns exec "$NSPID" ip route add "$GATEWAY/32" dev "$CONTAINER_IFNAME"
-      ip netns exec "$NSPID" ip route replace default via "$GATEWAY"
-    }
-    ;;
-esac
+  # When using any of the DHCP methods, we start a DHCP client in the
+  # network namespace of the container. With the 'dhcp' method, the
+  # client used is taken from the Docker busybox image (therefore
+  # requiring no specific client installed on the host). Other methods
+  # use a locally installed client.
+  case "$DHCP_CLIENT" in
+    dhcp)
+      docker run -d --net container:$GUESTNAME --cap-add NET_ADMIN \
+             busybox udhcpc -i "$CONTAINER_IFNAME" -x "hostname:$GUESTNAME" \
+             $DHCP_OPTIONS \
+             >/dev/null
+      ;;
+    udhcpc)
+      ip netns exec "$NSPID" "$DHCP_CLIENT" -qi "$CONTAINER_IFNAME" \
+                                            -x "hostname:$GUESTNAME" \
+                                            $DHCP_OPTIONS
+      ;;
+    dhclient)
+      ip netns exec "$NSPID" "$DHCP_CLIENT" "$CONTAINER_IFNAME" \
+                                            -pf "/var/run/dhclient.$NSPID.pid" \
+                                            -H "$GUESTNAME" \
+                                            $DHCP_OPTIONS
+      # kill dhclient after get ip address to prevent device be used after container close
+      kill "$(cat "/var/run/dhclient.$NSPID.pid")"
+      rm "/var/run/dhclient.$NSPID.pid"
+      ;;
+    dhcpcd)
+      ip netns exec "$NSPID" "$DHCP_CLIENT" -q "$CONTAINER_IFNAME" -h "$GUESTNAME"
+      ;;
+    "")
+      ip netns exec "$NSPID" ip addr add "$IPADDR" dev "$CONTAINER_IFNAME"
+      [ "$GATEWAY" ] && {
+        ip netns exec "$NSPID" ip route delete default >/dev/null 2>&1 && true
+      }
+      ip netns exec "$NSPID" ip link set "$CONTAINER_IFNAME" up
+      [ "$GATEWAY" ] && {
+        ip netns exec "$NSPID" ip route get "$GATEWAY" >/dev/null 2>&1 || \
+        ip netns exec "$NSPID" ip route add "$GATEWAY/32" dev "$CONTAINER_IFNAME"
+        ip netns exec "$NSPID" ip route replace default via "$GATEWAY"
+      }
+      ;;
+  esac
 
-# Give our ARP neighbors a nudge about the new interface
-if installed arping; then
-  IPADDR=$(echo "$IPADDR" | cut -d/ -f1)
-  ip netns exec "$NSPID" arping -c 1 -A -I "$CONTAINER_IFNAME" "$IPADDR" > /dev/null 2>&1 || true
-else
-  echo "Warning: arping not found; interface may not be immediately reachable"
+  # Give our ARP neighbors a nudge about the new interface
+  if installed arping; then
+    IPADDR=$(echo "$IPADDR" | cut -d/ -f1)
+    ip netns exec "$NSPID" arping -c 1 -A -I "$CONTAINER_IFNAME" "$IPADDR" > /dev/null 2>&1 || true
+  else
+    echo "Warning: arping not found; interface may not be immediately reachable"
+  fi
 fi
-
 # Remove NSPID to avoid `ip netns` catch it.
 rm -f "/var/run/netns/$NSPID"
 


### PR DESCRIPTION
Add support for route. Anything after "pipework <CONTAINER_ID> route" will be passed to `ip route` run inside the container.