### PR TITLE
Fix loose grep match

### DIFF
--- a/pipework
+++ b/pipework
@@ -263,7 +263,7 @@ MTU=$(ip link show "$IFNAME" | awk '{print $5}')
       (ip link set "$LOCAL_IFNAME" master "$IFNAME" > /dev/null 2>&1) || (brctl addif "$IFNAME" "$LOCAL_IFNAME")
       ;;
     openvswitch)
-      if ! ovs-vsctl list-ports "$IFNAME" | grep -q "$LOCAL_IFNAME"; then
+      if ! ovs-vsctl list-ports "$IFNAME" | grep -q "^${LOCAL_IFNAME}$"; then
         ovs-vsctl add-port "$IFNAME" "$LOCAL_IFNAME" ${VLAN:+tag="$VLAN"}
       fi
       ;;


### PR DESCRIPTION
When determining whether a port needs to be added to an ovs switch, pipework
first greps to see if a port by that name is on the switch, in which case it
skips adding the port.

The check uses a grep which also matches against ports which contain the name
to be added as a substring, erroneously determining that the port is already on
the switch.

This change tightens the grep to look for exactly the desired port name.