### PR TITLE
Create option to keep dhcp clients alive so they can manage (and renew) leases even after pipework exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,31 @@ through extra hoops if you want it to work properly.
 
 It works fine on plain old wired Ethernet, though.
 
+#### Lease Renewal
+
+All of the DHCP options - udhcpc, dhcp, dhclient, dhcpcd - exit or are killed by pipework when they are done assigning a lease. This is to prevent zombie processes from existing after a container exits, but the dhcp client still exists.
+
+However, if the container is long-running - longer than the life of the lease - then the lease will expire, no dhcp client renews the lease, and the container is stuck without a valid IP address.
+
+To resolve this problem, you can cause the dhcp client to remain alive. The method depends on the dhcp client you use.
+
+* dhcp: see the next section [DHCP Options](#dhcp-options)
+* dhclient: use DHCP client `dhclient-f`
+* udhcpc: use DHCP client `udhcpc-f`
+* dhcpcd: not yet supported.
+
+
+**Note:** If you use this option *you* will be responsible for finding and killing those dhcp client processes in the future. pipework is a one-time script; it is not intended to manage long-running processes for you.
+
+In order to find the processes, you can look for pidfiles in the following locations:
+
+* dhcp: see the next section [DHCP Options](#dhcp-options)
+* dhclient: pidfiles in `/var/run/dhclient.$GUESTNAME.pid`
+* udhcpc: pidfiles in `/var/run/udhcpc.$GUESTNAME.pid`
+* dhcpcd: not yet supported
+
+`$GUESTNAME` is the name or ID of the guest as you passed it to pipework on instantiation.
+
 
 ### DHCP Options
 

--- a/pipework
+++ b/pipework
@@ -192,8 +192,11 @@ case "$IPADDR" in
     fi
     DHCP_CLIENT=${IPADDR%%:*}
     ;;
-  udhcpc|udhcpc:*|dhcpcd|dhcpcd:*|dhclient|dhclient:*)
+  udhcpc|udhcpc:*|udhcpc-f|udhcpc-f:*|dhcpcd|dhcpcd:*|dhclient|dhclient:*|dhclient-f|dhclient-f:*)
     DHCP_CLIENT=${IPADDR%%:*}
+    # did they ask for the client to remain?
+    DHCP_FOREGROUND=$(echo $DHCP_CLIENT | grep '\-f')
+    DHCP_CLIENT=${DHCP_CLIENT%-f}
     if ! installed "$DHCP_CLIENT"; then
       die 1 "You asked for DHCP client $DHCP_CLIENT, but I can't find it."
     fi
@@ -341,17 +344,28 @@ case "$DHCP_CLIENT" in
            >/dev/null
     ;;
   udhcpc)
+    DHCP_Q="-q"
+    [ "$DHCP_FOREGROUND" ] && {
+      DHCP_OPTIONS="$DHCP_OPTIONS -f"
+    }
     ip netns exec "$NSPID" "$DHCP_CLIENT" -qi "$CONTAINER_IFNAME" \
                                           -x "hostname:$GUESTNAME" \
+                                          -p "/var/run/udhcpc.$GUESTNAME.pid" \
                                           $DHCP_OPTIONS
+    [ ! "$DHCP_FOREGROUND" ] && {
+      rm "/var/run/udhcpc.$GUESTNAME.pid"
+    }
     ;;
   dhclient)
     ip netns exec "$NSPID" "$DHCP_CLIENT" "$CONTAINER_IFNAME" \
-                                          -pf "/var/run/dhclient.$NSPID.pid" \
+                                          -pf "/var/run/dhclient.$GUESTNAME.pid" \
+                                          -lf "/etc/dhclient/dhclient.$GUESTNAME.leases" \
                                           $DHCP_OPTIONS
     # kill dhclient after get ip address to prevent device be used after container close
-    kill "$(cat "/var/run/dhclient.$NSPID.pid")"
-    rm "/var/run/dhclient.$NSPID.pid"
+    [ ! "$DHCP_FOREGROUND" ] && {
+      kill "$(cat "/var/run/dhclient.$GUESTNAME.pid")"
+      rm "/var/run/dhclient.$GUESTNAME.pid"
+    }
     ;;
   dhcpcd)
     ip netns exec "$NSPID" "$DHCP_CLIENT" -q "$CONTAINER_IFNAME" -h "$GUESTNAME"

--- a/pipework
+++ b/pipework
@@ -195,7 +195,10 @@ case "$IPADDR" in
   udhcpc|udhcpc:*|udhcpc-f|udhcpc-f:*|dhcpcd|dhcpcd:*|dhclient|dhclient:*|dhclient-f|dhclient-f:*)
     DHCP_CLIENT=${IPADDR%%:*}
     # did they ask for the client to remain?
-    DHCP_FOREGROUND=$(echo $DHCP_CLIENT | grep '\-f')
+    DHCP_FOREGROUND=
+    [ "${DHCP_CLIENT: -2}" = '-f' ] && {
+      DHCP_FOREGROUND=true
+    }
     DHCP_CLIENT=${DHCP_CLIENT%-f}
     if ! installed "$DHCP_CLIENT"; then
       die 1 "You asked for DHCP client $DHCP_CLIENT, but I can't find it."


### PR DESCRIPTION
Per this Issue https://github.com/jpetazzo/pipework/issues/181 , give users option to keep udhcpc and dhclient around to manage the lease. Also updated README.md to describe how it works and how to manage it.