### PR TITLE
Add "pipework rule" command for passing args to "ip rule" ; add "pipework tc" for passing args to "tc"

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ If you want to use `tc` from within the container namespace, you can do so with 
 
 Example, to simulate 30% packet loss on `eth0` within the container:
 
-  pipework tc $CONTAINERID qdisc add dev eth0 root netem loss 30%
+    pipework tc $CONTAINERID qdisc add dev eth0 root netem loss 30%
 
 
 ### Support Open vSwitch

--- a/README.md
+++ b/README.md
@@ -467,6 +467,16 @@ Note that for these rules to work you first need to execute the following in you
 You can read more on using route tables, specifically to setup multiple NICs with different default gateways,
 here: https://kindlund.wordpress.com/2007/11/19/configuring-multiple-default-routes-in-linux/
 
+### Control `tc`
+
+If you want to use `tc` from within the container namespace, you can do so with the command
+`pipework tc $CONTAINERID <tc_args>`.
+
+Example, to simulate 30% packet loss on `eth0` within the container:
+
+  pipework tc $CONTAINERID qdisc add dev eth0 root netem loss 30%
+
+
 ### Support Open vSwitch
 
 If you want to attach a container to the Open vSwitch bridge, no problem.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 **_Software-Defined Networking for Linux Containers_**
 
-Pipework lets you connect together containers in arbitrarily complex scenarios. 
-Pipework uses cgroups and namespace and works with "plain" LXC containers 
+Pipework lets you connect together containers in arbitrarily complex scenarios.
+Pipework uses cgroups and namespace and works with "plain" LXC containers
 (created with `lxc-start`), and with the awesome [Docker](http://www.docker.io/).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
@@ -219,7 +219,7 @@ macvlan interfaces is segregated from the "root" interface.
 
 If you want to enable that kind of communication, no problem: just
 create a macvlan interface in your host, and move the IP address from
-the "normal" interface to the macvlan interface. 
+the "normal" interface to the macvlan interface.
 
 For instance, on a machine where `eth0` is the main interface, and has
 address `10.1.1.123/24`, with gateway `10.1.1.254`, you would do this:
@@ -447,6 +447,25 @@ Here are some examples.
     pipework route $CONTAINERID replace default via 10.2.3.5.78
 
 Everything after the container ID (or name) will be run as an argument to `ip route` inside the container's namespace. Use the iproute2 man page.
+
+### Control Rules
+
+If you want to add/delete/replace IP rules in the container, you can do the same thing with `ip rule` that you can with
+`ip route`.
+
+Specify the interface to be `rule`, followed by the container ID or name, followed by the rule command.
+
+Here are some examples, to specify a route table:
+
+    pipework rule $CONTAINERID add from 172.19.0.2/32 table 1
+    pipework rule $CONTAINERID add to 172.19.0.2/32 table 1
+
+Note that for these rules to work you first need to execute the following in your container:
+
+  echo "1 admin" >> /etc/iproute2/rt_tables
+
+You can read more on using route tables, specifically to setup multiple NICs with different default gateways,
+here: https://kindlund.wordpress.com/2007/11/19/configuring-multiple-default-routes-in-linux/
 
 ### Support Open vSwitch
 

--- a/pipework
+++ b/pipework
@@ -66,6 +66,7 @@ esac
   echo "pipework <hostinterface> [-i containerinterface] [-l localinterfacename] <guest> dhcp [macaddr][@vlan]"
   echo "pipework route <guest> <route_command>"
   echo "pipework rule <guest> <rule_command>"
+  echo "pipework tc <guest> <tc_command>"
   echo "pipework --wait [-i containerinterface]"
   exit 1
 }
@@ -125,6 +126,9 @@ if [ -z "$WAIT" ]; then
         ;;
       rule*)
         IFTYPE=rule
+        ;;
+      tc*)
+        IFTYPE=tc
         ;;
       dummy*)
         IFTYPE=dummy
@@ -198,7 +202,7 @@ case "$N" in
 esac
 
 # only check IPADDR if we are not in a route mode
-[ "$IFTYPE" != route ] && [ "$IFTYPE" != rule ] && {
+[ "$IFTYPE" != route ] && [ "$IFTYPE" != rule ] && [ "$IFTYPE" != tc ] && {
   case "$IPADDR" in
 	  # Let's check first if the user asked for DHCP allocation.
 	  dhcp|dhcp:*)
@@ -282,7 +286,7 @@ ln -s "/proc/$NSPID/ns/net" "/var/run/netns/$NSPID"
   }
 }
 
-[ "$IFTYPE" != "route" ] && [ "$IFTYPE" != "dummy" ] && [ "$IFTYPE" != "rule" ] && MTU=$(ip link show "$IFNAME" | awk '{print $5}')
+[ "$IFTYPE" != "route" ] && [ "$IFTYPE" != "dummy" ] && [ "$IFTYPE" != "rule" ] && [ "$IFTYPE" != "tc" ] && MTU=$(ip link show "$IFNAME" | awk '{print $5}')
 
 # If it's a bridge, we need to create a veth pair
 [ "$IFTYPE" = bridge ] && {
@@ -367,6 +371,9 @@ if [ "$IFTYPE" = route ]; then
 elif [ "$IFTYPE" = rule ] ; then
   shift 2
   ip netns exec "$NSPID" ip rule "$@"
+elif [ "$IFTYPE" = tc ] ; then
+  shift 2
+  ip netns exec "$NSPID" tc "$@"
 else
   # Otherwise, run normally.
   ip link set "$GUEST_IFNAME" netns "$NSPID"

--- a/pipework
+++ b/pipework
@@ -65,6 +65,7 @@ esac
   echo "pipework <hostinterface> [-i containerinterface] [-l localinterfacename] [-a addressfamily] <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr][@vlan]"
   echo "pipework <hostinterface> [-i containerinterface] [-l localinterfacename] <guest> dhcp [macaddr][@vlan]"
   echo "pipework route <guest> <route_command>"
+  echo "pipework rule <guest> <rule_command>"
   echo "pipework --wait [-i containerinterface]"
   exit 1
 }
@@ -121,6 +122,9 @@ if [ -z "$WAIT" ]; then
         ;;
       route*)
         IFTYPE=route
+        ;;
+      rule*)
+        IFTYPE=rule
         ;;
       dummy*)
         IFTYPE=dummy
@@ -194,7 +198,7 @@ case "$N" in
 esac
 
 # only check IPADDR if we are not in a route mode
-[ "$IFTYPE" != route ] && {
+[ "$IFTYPE" != route ] && [ "$IFTYPE" != rule ] && {
   case "$IPADDR" in
 	  # Let's check first if the user asked for DHCP allocation.
 	  dhcp|dhcp:*)
@@ -278,7 +282,7 @@ ln -s "/proc/$NSPID/ns/net" "/var/run/netns/$NSPID"
   }
 }
 
-[ "$IFTYPE" != "route" ] && [ "$IFTYPE" != "dummy" ] && MTU=$(ip link show "$IFNAME" | awk '{print $5}')
+[ "$IFTYPE" != "route" ] && [ "$IFTYPE" != "dummy" ] && [ "$IFTYPE" != "rule" ] && MTU=$(ip link show "$IFNAME" | awk '{print $5}')
 
 # If it's a bridge, we need to create a veth pair
 [ "$IFTYPE" = bridge ] && {
@@ -360,6 +364,9 @@ if [ "$IFTYPE" = route ]; then
   # ... discard the first two arguments and pass the rest to the route command.
   shift 2
   ip netns exec "$NSPID" ip route "$@"
+elif [ "$IFTYPE" = rule ] ; then
+  shift 2
+  ip netns exec "$NSPID" ip rule "$@"
 else
   # Otherwise, run normally.
   ip link set "$GUEST_IFNAME" netns "$NSPID"


### PR DESCRIPTION
This is a simple commit that clones the functionality of `pipework route` for `pipework rule`, which passes args to `ip rule` instead of `ip route`.

I used this for configuring multiple NICs in a docker container and assigning each their own default gateway. For every NIC, I create a network. At container startup I connect it to one of the networks. After startup I connect it to the other networks. Then I add a route table for each NIC and set the default route separately for each one.

In my case this allows me to create proxy containers that can bind to multiple interfaces and forward traffic on multiple outbound IPs (e.g. using squidproxy).