### PR TITLE
Adding metadata to openvswitch database.

### DIFF
--- a/pipework
+++ b/pipework
@@ -181,6 +181,9 @@ case "$N" in
       RETRIES=3
       while [ "$RETRIES" -gt 0 ]; do
         DOCKERPID=$(docker inspect --format='{{ .State.Pid }}' "$GUESTNAME")
+        DOCKERCID=$(docker inspect --format='{{ .ID }}' "$GUESTNAME")
+        DOCKERCNAME=$(docker inspect --format='{{ .Name }}' "$GUESTNAME")
+
         [ "$DOCKERPID" != 0 ] && break
         sleep 1
         RETRIES=$((RETRIES - 1))
@@ -311,7 +314,14 @@ ln -s "/proc/$NSPID/ns/net" "/var/run/netns/$NSPID"
       ;;
     openvswitch)
       if ! ovs-vsctl list-ports "$IFNAME" | grep -q "^${LOCAL_IFNAME}$"; then
-        ovs-vsctl add-port "$IFNAME" "$LOCAL_IFNAME" ${VLAN:+tag="$VLAN"}
+        ovs-vsctl add-port "$IFNAME" "$LOCAL_IFNAME" ${VLAN:+tag="$VLAN"} \
+            -- set Interface "$LOCAL_IFNAME" \
+                external-ids:pipework.interface="$LOCAL_IFNAME" \
+                external-ids:pipework.bridge="$IFNAME" \
+                ${DOCKERCID:+external-ids:pipework.containerid="$DOCKERCID"} \
+                ${DOCKERCNAME:+external-ids:pipework.containername="$DOCKERCNAME"} \
+                ${NSPID:+external-ids:pipework.nspid="$NSPID"} \
+                ${VLAN:+external-ids:pipework.vlan="$VLAN"}
       fi
       ;;
   esac


### PR DESCRIPTION
Pipework doesn't populate the openvswitch database with any information
about the pipework interface creation. This makes it difficult to glean
any information about the container to which an interface is assigned.

This patch adds the bridge, interface name, container ID and vlan to
the database so other tools can query it.

This patch was originally designed to help tools like @dreamcat4's
docker-pipework image clean up these interfaces when the container is started
with something like 'docker run --rm' (with modifications).