### PR TITLE
fix: sh doesn't support substr syntax

### DIFF
--- a/pipework
+++ b/pipework
@@ -224,7 +224,7 @@ esac
 	    DHCP_CLIENT=${IPADDR%%:*}
 	    # did they ask for the client to remain?
 	    DHCP_FOREGROUND=
-	    [ "${DHCP_CLIENT: -2}" = '-f' ] && {
+	    [ "${DHCP_CLIENT%-f}" != "${DHCP_CLIENT}" ] && {
 	      DHCP_FOREGROUND=true
 	    }
 	    DHCP_CLIENT=${DHCP_CLIENT%-f}


### PR DESCRIPTION
By the way, would it be better to use `nsenter -un` instead of `ip netns exec`? `nsenter -un` will enter both network namespace and UTS namespace, while `ip netns exec` only enter network namespace.