### PR TITLE
Allow to specify host interface via mac address

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Pipework uses cgroups and namespace and works with "plain" LXC containers
 - [Using a different netmask](#using-a-different-netmask)
 - [Setting a default gateway](#setting-a-default-gateway)
 - [Connect a container to a local physical interface](#connect-a-container-to-a-local-physical-interface)
+- [Use MAC address to specify physical interface](#use-mac-address-to-specify-physical-interface)
 - [Let the Docker host communicate over macvlan interfaces](#let-the-docker-host-communicate-over-macvlan-interfaces)
 - [Wait for the network to be ready](#wait-for-the-network-to-be-ready)
 - [Add the interface without an IP address](#add-the-interface-without-an-ip-address)
@@ -209,6 +210,23 @@ an interface exclusively to a container without using a macvlan bridge.
 
 This is useful for assigning SR-IOV VFs to containers, but be aware of added
 latency when using the NIC to switch packets between containers on the same host.
+
+
+### Use MAC address to specify physical interface
+
+In case you want to connect a local physical interface with a specific name inside
+the container, it will also rename the physical one, this behaviour is not
+idempotent:
+
+    pipework --direct-phys eth1 -i container0 $CONTAINERID 0/0
+    # second call would fail because physical interface eth1 has been renamed
+
+We can use the interface MAC address to identify the interface the same way
+any time (udev networking rules use a similar method for interfaces persistent
+naming):
+
+    pipework --direct-phys mac:00:f3:15:4a:42:c8 -i container0 $CONTAINERID 0/0
+
 
 ### Let the Docker host communicate over macvlan interfaces
 

--- a/pipework
+++ b/pipework
@@ -64,6 +64,8 @@ esac
   echo "Syntax:"
   echo "pipework <hostinterface> [-i containerinterface] [-l localinterfacename] [-a addressfamily] <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr][@vlan]"
   echo "pipework <hostinterface> [-i containerinterface] [-l localinterfacename] <guest> dhcp [macaddr][@vlan]"
+  echo "pipework mac:<hostinterface_macaddress> [-i containerinterface] [-l localinterfacename] [-a addressfamily] <guest> <ipaddr>/<subnet>[@default_gateway] [macaddr][@vlan]"
+  echo "pipework mac:<hostinterface_macaddress> [-i containerinterface] [-l localinterfacename] <guest> dhcp [macaddr][@vlan]"
   echo "pipework route <guest> <route_command>"
   echo "pipework rule <guest> <rule_command>"
   echo "pipework tc <guest> <tc_command>"
@@ -89,6 +91,23 @@ die () {
   warn "$@"
   exit "$status"
 }
+
+if echo $IFNAME | grep -q '^mac:'; then
+  mac_address=$(echo $IFNAME | cut -c5-)
+  ifmatch=
+  for iftest in /sys/class/net/*; do
+    if [ -f $iftest/address ] && [ "$mac_address" = "$(cat $iftest/address)" ]; then
+      ifmatch="$(basename $iftest)"
+      break
+    fi
+  done
+
+  if [ -z "$ifmatch" ]; then
+    die 1 "Mac address $mac_address specified for interface but no host interface matched."
+  else
+    IFNAME=$ifmatch
+  fi
+fi
 
 # First step: determine type of first argument (bridge, physical interface...),
 # Unless "--wait" is set (then skip the whole section)


### PR DESCRIPTION
When using commands such as:
```
pipework --direct-phys eth0 -i iface1 <docker_pid> 0/0
```

The physical interface eth0 gets renamed as iface1 in the host context and the behavior is not idempotent.
Adding support to specify the interface through its MAC address, such as:
```
pipework --direct-phys mac:00:f3:15:4a:42:c8 -i iface1 <docker_pid> 0/0
```

This may be useful when the physical interface to "pipework" is eth0 (might already exist in a "usual" docker container).