### PR TITLE
Fix docker container lookup

### DIFF
--- a/pipework
+++ b/pipework
@@ -194,6 +194,9 @@ done < /proc/mounts
 # Try to find a cgroup matching exactly the provided name.
 M=$(find "$CGROUPMNT" -name "$GUESTNAME")
 N=$(echo "$M" | wc -l)
+if [ -z "$M" ] ; then
+    N=0
+fi
 case "$N" in
   0)
     # If we didn't find anything, try to lookup the container with Docker.


### PR DESCRIPTION
Executing `echo "" | wc -l` results in 1, causing the code to expect
a cgroup matching the guest name when there is no such cgroup.

Check explicitly for empty output in the results of searching
the cgroup.