### PR TITLE
Use iw command to set the namespace of a wireless interface

### DIFF
--- a/pipework
+++ b/pipework
@@ -412,7 +412,11 @@ elif [ "$IFTYPE" = tc ] ; then
   ip netns exec "$NSPID" tc "$@"
 else
   # Otherwise, run normally.
-  ip link set "$GUEST_IFNAME" netns "$NSPID"
+  if iw dev | awk '$1=="Interface"{print $2}' | grep $GUEST_IFNAME > /dev/null; then
+    iw phy $(iw dev | grep -B 1 $GUEST_IFNAME | grep phy# | sed 's/#//g') set netns $NSPID
+  else
+    ip link set "$GUEST_IFNAME" netns "$NSPID"
+  fi
   ip netns exec "$NSPID" ip link set "$GUEST_IFNAME" name "$CONTAINER_IFNAME"
   [ "$MACADDR" ] && ip netns exec "$NSPID" ip link set dev "$CONTAINER_IFNAME" address "$MACADDR"
 

--- a/pipework
+++ b/pipework
@@ -412,7 +412,7 @@ elif [ "$IFTYPE" = tc ] ; then
   ip netns exec "$NSPID" tc "$@"
 else
   # Otherwise, run normally.
-  if iw dev | awk '$1=="Interface"{print $2}' | grep $GUEST_IFNAME > /dev/null; then
+  if command -v iw && iw dev | awk '$1=="Interface"{print $2}' | grep $GUEST_IFNAME > /dev/null; then
     iw phy $(iw dev | grep -B 1 $GUEST_IFNAME | grep phy# | sed 's/#//g') set netns $NSPID
   else
     ip link set "$GUEST_IFNAME" netns "$NSPID"


### PR DESCRIPTION
When trying to move a wireless interface using --direct-phys option, the command is failing with "RTNETLINK answers: Invalid argument"
This issue is caused by the following command : ip link set "$GUEST_IFNAME" netns "$NSPID"
To fix that we need to use iw iso ip 
