### PR TITLE
docker run for busybox udhcpc: add --rm flag

### DIFF
--- a/pipework
+++ b/pipework
@@ -427,7 +427,7 @@ else
 	# use a locally installed client.
 	case "$DHCP_CLIENT" in
 	  dhcp)
-	    docker run -d --net container:$GUESTNAME --cap-add NET_ADMIN \
+	    docker run --rm -d --net container:$GUESTNAME --cap-add NET_ADMIN \
 	           busybox udhcpc -i "$CONTAINER_IFNAME" -x "hostname:$GUESTNAME" \
 	           $DHCP_OPTIONS \
 	           >/dev/null


### PR DESCRIPTION
Use --rm with "docker run", so the remaining container does not consume
disk space after the command is done.