### PR TITLE
Add workaround for cgroupv2 + Minure fixes

### DIFF
--- a/pipework
+++ b/pipework
@@ -180,22 +180,26 @@ CONTAINER_IFNAME=${CONTAINER_IFNAME:-eth1}
   die 1 "MACADDR configuration unsupported for IPoIB interfaces."
 }
 
-# Second step: find the guest (for now, we only support LXC containers)
-while read _ mnt fstype options _; do
-  [ "$fstype" != "cgroup" ] && continue
-  echo "$options" | grep -qw devices || continue
-  CGROUPMNT=$mnt
-done < /proc/mounts
-
-[ "$CGROUPMNT" ] || {
-    die 1 "Could not locate cgroup mount point."
-}
-
-# Try to find a cgroup matching exactly the provided name.
-M=$(find "$CGROUPMNT" -name "$GUESTNAME")
-N=$(echo "$M" | wc -l)
-if [ -z "$M" ] ; then
+if grep cgroup2 /proc/filesystems > /dev/null ; then 
     N=0
+else
+    # Second step: find the guest (for now, we only support LXC containers)
+    while read _ mnt fstype options _; do
+    [ "$fstype" != "cgroup" ] && continue
+    echo "$options" | grep -qw devices || continue
+    CGROUPMNT=$mnt
+    done < /proc/mounts
+
+    [ "$CGROUPMNT" ] || {
+        die 1 "Could not locate cgroup mount point."
+    }
+
+    # Try to find a cgroup matching exactly the provided name.
+    M=$(find "$CGROUPMNT" -name "$GUESTNAME")
+    N=$(echo "$M" | wc -l)
+    if [ -z "$M" ] ; then
+        N=0
+    fi
 fi
 case "$N" in
   0)
@@ -368,6 +372,7 @@ ln -s "/proc/$NSPID/ns/net" "/var/run/netns/$NSPID"
     GUEST_IFNAME=$IFNAME
   else
     GUEST_IFNAME=ph$NSPID$CONTAINER_IFNAME
+    GUEST_IFNAME=${GUEST_IFNAME:0:15}
     ip link add link "$IFNAME" dev "$GUEST_IFNAME" mtu "$MTU" type macvlan mode bridge
   fi
 
@@ -412,7 +417,7 @@ elif [ "$IFTYPE" = tc ] ; then
   ip netns exec "$NSPID" tc "$@"
 else
   # Otherwise, run normally.
-  if command -v iw && iw dev | awk '$1=="Interface"{print $2}' | grep $GUEST_IFNAME > /dev/null; then
+if command -v iw > /dev/null && iw dev | awk '$1=="Interface"{print $2}' | grep $GUEST_IFNAME > /dev/null; then
     iw phy $(iw dev | grep -B 1 $GUEST_IFNAME | grep phy# | sed 's/#//g') set netns $NSPID
   else
     ip link set "$GUEST_IFNAME" netns "$NSPID"

--- a/pipework
+++ b/pipework
@@ -181,25 +181,25 @@ CONTAINER_IFNAME=${CONTAINER_IFNAME:-eth1}
 }
 
 if grep cgroup2 /proc/filesystems > /dev/null ; then 
-    N=0
+  N=0
 else
-    # Second step: find the guest (for now, we only support LXC containers)
-    while read _ mnt fstype options _; do
+  # Second step: find the guest (for now, we only support LXC containers)
+  while read _ mnt fstype options _; do
     [ "$fstype" != "cgroup" ] && continue
     echo "$options" | grep -qw devices || continue
     CGROUPMNT=$mnt
-    done < /proc/mounts
+  done < /proc/mounts
 
-    [ "$CGROUPMNT" ] || {
-        die 1 "Could not locate cgroup mount point."
-    }
+  [ "$CGROUPMNT" ] || {
+    die 1 "Could not locate cgroup mount point."
+  }
 
-    # Try to find a cgroup matching exactly the provided name.
-    M=$(find "$CGROUPMNT" -name "$GUESTNAME")
-    N=$(echo "$M" | wc -l)
-    if [ -z "$M" ] ; then
-        N=0
-    fi
+  # Try to find a cgroup matching exactly the provided name.
+  M=$(find "$CGROUPMNT" -name "$GUESTNAME")
+  N=$(echo "$M" | wc -l)
+  if [ -z "$M" ] ; then
+    N=0
+  fi
 fi
 case "$N" in
   0)
@@ -417,7 +417,7 @@ elif [ "$IFTYPE" = tc ] ; then
   ip netns exec "$NSPID" tc "$@"
 else
   # Otherwise, run normally.
-if command -v iw > /dev/null && iw dev | awk '$1=="Interface"{print $2}' | grep $GUEST_IFNAME > /dev/null; then
+  if command -v iw > /dev/null && iw dev | awk '$1=="Interface"{print $2}' | grep $GUEST_IFNAME > /dev/null; then
     iw phy $(iw dev | grep -B 1 $GUEST_IFNAME | grep phy# | sed 's/#//g') set netns $NSPID
   else
     ip link set "$GUEST_IFNAME" netns "$NSPID"


### PR DESCRIPTION
1- Add a workaround for cgroupv2 working only for docker.
2- Remove output of "command -v" from the console traces.
3- Truncate the length of GUEST_IFNAME as "ip link add ..." command doe not supports names with size higher than 15 chars. 