### PR TITLE
Change shebang to /bin/bash

### DIFF
--- a/pipework
+++ b/pipework
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This code should (try to) follow Google's Shell Style Guide
 # (https://google.github.io/styleguide/shell.xml)
 set -e


### PR DESCRIPTION
In Ubuntu the default shell points to `dash` rather than `bash`. As such, this substitution (line 375):
```
    GUEST_IFNAME=${GUEST_IFNAME:0:15}
```
returns an error as that syntax is not supported by `dash`. Setting the shebang do `/bin/bash` fixes this.