### PR TITLE
Revert #252 and replace the bash-specific substitution with a general…

### DIFF
--- a/pipework
+++ b/pipework
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This code should (try to) follow Google's Shell Style Guide
 # (https://google.github.io/styleguide/shell.xml)
 set -e
@@ -372,7 +372,7 @@ ln -s "/proc/$NSPID/ns/net" "/var/run/netns/$NSPID"
     GUEST_IFNAME=$IFNAME
   else
     GUEST_IFNAME=ph$NSPID$CONTAINER_IFNAME
-    GUEST_IFNAME=${GUEST_IFNAME:0:15}
+    GUEST_IFNAME=$(echo $GUEST_IFNAME | cut -c 1-15)
     ip link add link "$IFNAME" dev "$GUEST_IFNAME" mtu "$MTU" type macvlan mode bridge
   fi
 


### PR DESCRIPTION
… one using cut.

This has been requested in order to support alpine and busybox, which don't have bash.