### PR TITLE
Fix MTU detection when PCI Virtual Functions are present

### DIFF
--- a/pipework
+++ b/pipework
@@ -319,7 +319,7 @@ ln -s "/proc/$NSPID/ns/net" "/var/run/netns/$NSPID"
   }
 }
 
-[ "$IFTYPE" != "route" ] && [ "$IFTYPE" != "dummy" ] && [ "$IFTYPE" != "rule" ] && [ "$IFTYPE" != "tc" ] && MTU=$(ip link show "$IFNAME" | awk '{print $5}')
+[ "$IFTYPE" != "route" ] && [ "$IFTYPE" != "dummy" ] && [ "$IFTYPE" != "rule" ] && [ "$IFTYPE" != "tc" ] && MTU=$(ip link show "$IFNAME" | awk '$4=="mtu"{print $5}')
 
 # If it's a bridge, we need to create a veth pair
 [ "$IFTYPE" = bridge ] && {


### PR DESCRIPTION
Currently, pipework uses this expression to extract netif MTU:

```bash
MTU=$(ip link show "$IFNAME" | awk '{print $5}'
```

When used with an Intel Ethernet device that have SR-IOV Virtual Functions configured, the `ip link show` command would output something like this:

```text
$ ip link show eno2
146: eno2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether a4:bf:01:00:00:00 brd ff:ff:ff:ff:ff:ff
    vf 0     link/ether 52:de:ff:3d:00:03 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
    vf 1     link/ether 52:de:ff:3d:02:03 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
    vf 2     link/ether 52:de:ff:3d:03:03 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
    vf 3     link/ether 52:de:ff:3d:04:03 brd ff:ff:ff:ff:ff:ff, spoof checking on, link-state auto, trust off
```

Consequently, the `$MTU` variable would contain not only the MTU value but also "brd" token from subsequent lines.

This patch inserts a `$4=="mtu"` condition so that the awk subcommand only prints the MTU value and skips other lines.